### PR TITLE
Fixed mediaId indexing on state notifications

### DIFF
--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -106,7 +106,7 @@ module.exports = class Media {
 
         this.status = C.STATUS.STOPPED;
         Logger.info(LOG_PREFIX, "Session", this.id, "stopped with status", this.status);
-        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.id, mediaSessionId: this.mediaSessionId });
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.mediaSessionId, mediaSessionId: this.mediaSessionId });
 
         return Promise.resolve();
       }
@@ -135,7 +135,8 @@ module.exports = class Media {
 
   _dispatchMediaStateEvent (event) {
     if (!this._mediaStateSubscription) {
-      Logger.debug("[mcs-media-session] Media session", this.id, "queuing event", { mediaId: this.id, ...event });
+      event = { mediaSessionId: this.mediaSessionId, mediaId: this.mediaSessionId, ...event };
+      Logger.debug("[mcs-media-session] Media session", this.id, "queuing event", event);
       this.eventQueue.push(event);
     }
     else {
@@ -148,8 +149,9 @@ module.exports = class Media {
 
   _dispatchIceCandidate (event) {
     if (!this._iceSubscription) {
+      event = { mediaSessionId: this.mediaSessionId, mediaId: this.mediaSessionId, ...event };
       Logger.debug("[mcs-media-session] Media session", this.id, "queuing event", event);
-      this.outboundIceQueue.push({ mediaId: this.id, ...event});
+      this.outboundIceQueue.push(event);
     }
     else {
       // TODO mediaId should be this.id?


### PR DESCRIPTION
This was causing some ICE candidates to be lost when they were supposed to reach the client. Should improve reliability on viewer connections.