### PR TITLE
mDNS candidates, error reporting and user clearance on WS disconnection

### DIFF
--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -292,6 +292,16 @@ const MR = class MCSRouter {
     return response;
   }
 
+  _disconnectAllClientSessions (client) {
+    client.userSessions.forEach(async s => {
+      try {
+        await this.leave(s);
+      } catch (e) {
+        this._handleError(e, 'leave');
+      }
+    });
+    client.userSessions = [];
+  };
   /**
    * Setup a new client.
    * After calling this method, the server will be able to handle
@@ -302,23 +312,27 @@ const MR = class MCSRouter {
     const id = clientId++;
     this.clients[id] = client;
     client.trackingId = id;
+    client.userSessions = [];
 
     client.on('close', () => {
       this._removeClientFromEventMap(client);
       this._removeClientFromTracking(client);
+      this._disconnectAllClientSessions(client);
     });
 
     client.on('error', () => {
       this._removeClientFromEventMap(client);
       this._removeClientFromTracking(client);
+      this._disconnectAllClientSessions(client);
     });
 
     client.on('join', async (args) =>  {
-      let transactionId;
+      let transactionId, room_id;
       try {
-        ({ transactionId } = args);
+        ({ transactionId, room_id } = args);
         const userId = await this.join(args);
         client.joined(userId, { transactionId });
+        client.userSessions.push({ userId, roomId: room_id });
       } catch (e) {
         this._notifyMethodError(client, e, transactionId);
       }

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -128,13 +128,16 @@ module.exports = class MediaSession {
       sinkMedias.forEach(sm => {
         Logger.trace("[mcs-media-session] Adapter elements to be connected", sourceMedia.adapterElementId, "=>", sm.adapterElementId);
         try {
-          return sourceMedia.adapter.connect(
+          sourceMedia.adapter.connect(
             sourceMedia.adapterElementId,
             sm.adapterElementId,
             connectionType,
           );
         } catch (err) {
-          throw (this._handleError(err));
+          // Temporarily supress connect error throw until we fix
+          // the mediaProfile spec
+          //throw (this._handleError(err));
+          Logger.error(LOG_PREFIX, err);
         }
       });
     }

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -470,10 +470,6 @@ module.exports = class SdpWrapper {
     res.media.forEach(ml => {
       if (ml.type === 'video' && codec !== 'ANY') {
         // Video: filter by @codec
-        const availablePayloads = ml.rtp.map(elem => {
-          return elem.payload;
-        });
-
         ml.rtp = ml.rtp.filter((elem) => {
           return elem.codec.toUpperCase() === codec;
         });


### PR DESCRIPTION
Progress on the 2.2.3 release.
Added:
  - A stub to check for mDNS ICE candidates (https://tools.ietf.org/html/draft-mdns-ice-candidates-00). They're being ignored right now as not to break anything in the ICE processing, but I left a stub to discover the IP via mDNS and when the time is right I'll finish that implementation. These candidates usually pop up in Apple/Safari devices and are only useful on a local-only network setup.
  - Improved error reporting in the Kurento adapter
  - Clearing users associated to a WS session when it ends