### PR TITLE
Fixed edge case on detecting Kurento crashes

### DIFF
--- a/lib/mcs-core/lib/media/balancer.js
+++ b/lib/mcs-core/lib/media/balancer.js
@@ -130,8 +130,8 @@ class Balancer extends EventEmitter {
       client.on('disconnect', () => {
         this._onDisconnection(host);
       });
-      client.on('reconnected', () => {
-        this._onReconnection(host);
+      client.on('reconnected', (sameSession) => {
+        this._onReconnection(sameSession, host);
       });
     }
     catch (err) {
@@ -156,10 +156,10 @@ class Balancer extends EventEmitter {
     }
   }
 
-  _onReconnection (sameSession) {
+  _onReconnection (sameSession, host) {
     if (!sameSession) {
-      Logger.info('[mcs-media] Media server is back online');
-      this.emit(C.EVENT.MEDIA_SERVER_ONLINE);
+      Logger.warn('[mcs-media] Media server reconnected, but it is not the same session');
+      this._onDisconnection(host);
     }
   }
 
@@ -188,10 +188,10 @@ class Balancer extends EventEmitter {
             clearInterval(this._reconnectionRoutine[id]);
             delete this._reconnectionRoutine[id];
             this.hosts.push(h);
+            Logger.warn("[mcs-media] Reconnection to media server succeeded", id, url);
           }).catch(e => {
             Logger.info("[mcs-balancer] Failed to reconnect to host", id);
           });
-          Logger.warn("[mcs-media] Reconnection to media server succeeded", id, url);
         } catch (err) {
           Logger.info("[mcs-balancer] Failed to reconnect to host", id);
         }


### PR DESCRIPTION
- Properly watch for the `sameSession` identifier to see if the reconnection happened between the `failAfter` period and things should be cleaned up and clients notified that the server crashed.