### PR TITLE
Move to use VP8 as the default codec for webcams

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -92,7 +92,7 @@ media-server-adapters:
 # _video_main refers to webcam/main video content, _video_content refers to
 # screenshare/content:slides streams.
 conference-media-specs:
-  codec_video_main: H264
+  codec_video_main: VP8
   codec_video_content: H264
   codec_audio: "ANY"
   H264:


### PR DESCRIPTION
iOS 12.2 enabled VP8 in Safari Mobile, so we can safely switch to using VP8 for all devices.  This should also make BigBlueButton usable by a broader segment of Android phones as well.