### PR TITLE
Disable forced keyframe interval for screensharing

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -23,7 +23,7 @@ to-stream: to-sfu-redis-channel
 from-stream: from-stream-sfu
 to-html5: to-html5-redis-channel
 common-message-version: 2.x
-screenshareKeyframeInterval: 2
+screenshareKeyframeInterval: 0
 
 recordScreenSharing: true
 recordWebcams: true


### PR DESCRIPTION
Since we will be dropping Flash interop soon enough, I'm disabling the forced keyframe
interval we used for screensharing. This should lower bandwidth, increase stream
quality and hopefully avoid some glib loop issues I suspect are happening due to this.