### PR TITLE
Properly throw an error when theres no media server host available

### DIFF
--- a/lib/mcs-core/lib/media/balancer.js
+++ b/lib/mcs-core/lib/media/balancer.js
@@ -76,10 +76,12 @@ class Balancer extends EventEmitter {
 
   async getHost () {
     const host = this._fetchAvailableHost();
-    if (host) {
-      Logger.info("[mcs-balancer] Chosen host is", host.id, host.url, host.ip, host.video, host.audio);
-      return host;
+    if (host == null) {
+      throw C.ERROR.MEDIA_SERVER_OFFLINE;
     }
+
+    Logger.info("[mcs-balancer] Chosen host is", host.id, host.url, host.ip, host.video, host.audio);
+    return host;
   }
 
   retrieveHost (hostId) {


### PR DESCRIPTION
Fix an issue with not throwing the `MEDIA_SERVER_OFFLINE` errors on subsequent tries when Kurento is offline.