### PR TITLE
Fixed race condition with host reconnection

### DIFF
--- a/lib/mcs-core/lib/media/balancer.js
+++ b/lib/mcs-core/lib/media/balancer.js
@@ -85,9 +85,19 @@ class Balancer extends EventEmitter {
   }
 
   retrieveHost (hostId) {
-    return this.hosts.find(host => host.id == hostId);
+    return this.hosts.find(host => host.id === hostId);
   }
 
+  addHost (host) {
+    const { id } = host;
+    if (id) {
+      this.removeHost(id);
+      this.hosts.push(host);
+      return;
+    }
+
+    Logger.warn("[mcs-balancer] Undefined ID for media server host, should not happen");
+  }
   removeHost (hostId) {
     this.hosts = this.hosts.filter(host => host.id !== hostId);
   }
@@ -109,13 +119,17 @@ class Balancer extends EventEmitter {
   }
 
   _fetchAvailableHost () {
+    if (this.hosts.length <= 0) {
+      throw C.ERROR.MEDIA_SERVER_OFFLINE;
+    }
+
     let host = this.hosts.find(host => host.video < VIDEO_TRANSPOSING_CEILING &&
       host.audio < AUDIO_TRANSPOSING_CEILING);
 
     // Round robin if all instances are fully loaded
     if (host == null) {
       host = this.hosts.shift();
-      this.hosts.push(host);
+      this.addHost(host);
     }
 
     return host;
@@ -189,7 +203,7 @@ class Balancer extends EventEmitter {
             this._monitorConnectionState(host);
             clearInterval(this._reconnectionRoutine[id]);
             delete this._reconnectionRoutine[id];
-            this.hosts.push(h);
+            this.addHost(h);
             Logger.warn("[mcs-media] Reconnection to media server succeeded", id, url);
           }).catch(e => {
             Logger.info("[mcs-balancer] Failed to reconnect to host", id);


### PR DESCRIPTION
There was an issue with host reconnection happening alongside with streams creation that made mcs-core account `undefined` hosts as valid ones. That would trigger an uncaught exception which would render a Kurento host unresponsive. Should be fixed now.

Also unified how hosts are added/removed.