### PR TITLE
Add optional config to set redis password

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -7,6 +7,8 @@ localIpAddress: ""
 acceptSelfSignedCertificate: false
 redisHost: 127.0.0.1
 redisPort: "6379"
+# Uncomment to set a password if Redis requires auth.
+# redisPassword: foobared
 clientPort: "3008"
 minVideoPort: 30000
 maxVideoPort: 33000

--- a/lib/bbb/pubsub/RedisWrapper.js
+++ b/lib/bbb/pubsub/RedisWrapper.js
@@ -37,7 +37,7 @@ module.exports = class RedisWrapper extends EventEmitter {
     var options = {
       host : config.get('redisHost'),
       port : config.get('redisPort'),
-      //password: config.get('redis.password')
+      password: config.has('redisPassword')? config.get('redisPassword') : undefined,
       retry_strategy: this._redisRetry
     };
 
@@ -54,7 +54,7 @@ module.exports = class RedisWrapper extends EventEmitter {
     var options = {
       host : config.get('redisHost'),
       port : config.get('redisPort'),
-      //password: config.get('redis.password')
+      password: config.has('redisPassword')? config.get('redisPassword') : undefined,
       retry_strategy: this._redisRetry
     };
 


### PR DESCRIPTION
If the `redisPassword` config property is set, it'll be used for auth. Just remove it from the `default.yml` file if the Redis server doesn't require auth.

The default example file has it commented out with a description.