### PR TITLE
Make HttpServer unknown errors non-fatal

### DIFF
--- a/lib/connection-manager/HttpServer.js
+++ b/lib/connection-manager/HttpServer.js
@@ -26,8 +26,7 @@ module.exports = class HttpServer {
     } else if (e.code === 'ECONNRESET') {
        Logger.warn("[HttpServer] Server throw ECONNRESET for a socket", e);
     } else {
-      Logger.info("[HttpServer] Unknown error", e, "; abort this instance");
-      throw e;
+      Logger.error("[HttpServer] Returned error", e);
     }
   }
 


### PR DESCRIPTION
Until I take SFU's HTTP/WS server out of the master process, catch all the errors it might throw to avoid crashing the master proc and triggering a restart.