### PR TITLE
Add per-stream bandwidth config option to upper layer video process

### DIFF
--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -60,8 +60,11 @@ module.exports = class User {
   subscribe (sdp, type, source, params = {}) {
     return new Promise(async (resolve, reject) => {
       try {
-        // Fetch the source media specs to make the subscriber match it
-        params.mediaSpecs = source.mediaSpecs;
+        // If there's not source media specs, fetch the source's media specs to
+        // make the subscriber match it
+        if (params.mediaSpecs == null) {
+          params.mediaSpecs = source.mediaSpecs;
+        }
 
         const session = this.createMediaSession(sdp, type, params);
         const answer = await this.startSession(session.id);

--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -12,6 +12,9 @@ const BaseManager = require('../base/BaseManager');
 const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
 const errors = require('../base/errors');
+const config = require('config');
+const DEFAULT_MEDIA_SPECS = config.get('conference-media-specs');
+const BW_UNCAPPED = 0;
 
 module.exports = class VideoManager extends BaseManager {
   constructor (connectionChannel, additionalChannels, logPrefix) {
@@ -93,7 +96,14 @@ module.exports = class VideoManager extends BaseManager {
 
 
         try {
-          const sdpAnswer = await video.start(message.sdpOffer);
+          // Only apply bitrate cap to publishers.
+          const bitrate = shared? message.bitrate : BW_UNCAPPED;
+          let mediaSpecs = JSON.parse(JSON.stringify(DEFAULT_MEDIA_SPECS));
+          if (bitrate != null) {
+            this._addBwToSpec(mediaSpecs, bitrate);
+          }
+
+          const sdpAnswer = await video.start(message.sdpOffer, mediaSpecs);
 
           // Empty ice queue after starting video
           this._flushIceQueue(video, iceQueue);
@@ -183,5 +193,13 @@ module.exports = class VideoManager extends BaseManager {
         Video.setSource(userId, stream.replace(/\|SIP/ig, ''));
       }
     });
+  }
+
+  _addBwToSpec (spec, bitrate) {
+    spec['H264'].as_main = bitrate;
+    spec['H264'].tias_main = (bitrate >>> 0) * 1000;
+    spec['VP8'].as_main = bitrate;
+    spec['VP8'].tias_main = (bitrate >>> 0) * 1000;
+    return spec;
   }
 }

--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -13,7 +13,9 @@ const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
 const errors = require('../base/errors');
 const config = require('config');
-const DEFAULT_MEDIA_SPECS = config.get('conference-media-specs');
+// Unfreeze the config's default media specs
+const DEFAULT_MEDIA_SPECS = JSON.parse(JSON.stringify(config.get('conference-media-specs')));
+
 const BW_UNCAPPED = 0;
 
 module.exports = class VideoManager extends BaseManager {
@@ -98,7 +100,9 @@ module.exports = class VideoManager extends BaseManager {
         try {
           // Only apply bitrate cap to publishers.
           const bitrate = shared? message.bitrate : BW_UNCAPPED;
-          let mediaSpecs = JSON.parse(JSON.stringify(DEFAULT_MEDIA_SPECS));
+          // Create a new spec for this instance
+          let mediaSpecs = { ...DEFAULT_MEDIA_SPECS };
+
           if (bitrate != null) {
             this._addBwToSpec(mediaSpecs, bitrate);
           }

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -215,7 +215,7 @@ module.exports = class Video extends BaseProvider {
     Logger.info(LOG_PREFIX, 'Recording status for rec', mediaId, 'for video', this.streamName, "is", name, state, details);
   }
 
-  start (sdpOffer) {
+  start (sdpOffer, mediaSpecs) {
     return new Promise(async (resolve, reject) => {
       Logger.info(LOG_PREFIX, "Starting video instance for", this.streamName);
       if (this.status !== C.MEDIA_STOPPING && this._status !== C.MEDIA_STOPPED) {
@@ -230,7 +230,7 @@ module.exports = class Video extends BaseProvider {
           this.userId = await this.mcs.join(this.voiceBridge, 'SFU', {});
           this.mediaUserJoined(this.streamName);
           Logger.info(LOG_PREFIX, "MCS join for", this.streamName, "returned", this.userId);
-          const sdpAnswer = await this._addMCSMedia(C.WEBRTC, sdpOffer);
+          const sdpAnswer = await this._addMCSMedia(C.WEBRTC, sdpOffer, mediaSpecs);
 
           this.mcs.onEvent(C.MEDIA_STATE, this.mediaId, (event) => {
             this._mediaStateWebRTC(event, this.mediaId);
@@ -256,13 +256,14 @@ module.exports = class Video extends BaseProvider {
     });
   }
 
-  _addMCSMedia (type, descriptor) {
+  _addMCSMedia (type, descriptor, mediaSpecs) {
     return new Promise(async (resolve, reject) => {
       try {
         if (this.shared) {
           const options = {
             descriptor,
             name: this._assembleStreamName('publish', this.id, this.voiceBridge),
+            mediaSpecs,
           }
 
           const { mediaId, answer } = await this.mcs.publish(this.userId, this.voiceBridge, type, options);
@@ -273,13 +274,13 @@ module.exports = class Video extends BaseProvider {
         else {
           Logger.info(LOG_PREFIX, "Subscribing to", this.id, sources);
           if (sources[this.id]) {
-            const answer = this._subscribeToMedia(descriptor);
+            const answer = this._subscribeToMedia(descriptor, mediaSpecs);
             return resolve(answer);
           } else {
             const lazySubscribe = (id) => {
               Logger.info(LOG_PREFIX, "Lazily subscribing to", id, "in", this.id);
               if (id === this.id) {
-                const answer = this._subscribeToMedia(descriptor);
+                const answer = this._subscribeToMedia(descriptor, mediaSpecs);
                 emitter.removeListener(C.VIDEO_SOURCE_ADDED, lazySubscribe);
                 return resolve(answer);
               }
@@ -297,11 +298,12 @@ module.exports = class Video extends BaseProvider {
     });
   }
 
-  async _subscribeToMedia (descriptor) {
+  async _subscribeToMedia (descriptor, mediaSpecs) {
     try {
       const options = {
         descriptor,
         name: this._assembleStreamName('subscribe', this.id, this.voiceBridge),
+        mediaSpecs,
       }
       Logger.info(LOG_PREFIX, 'Subscribing to', sources[this.id], 'from', this.id);
       const { mediaId, answer } = await this.mcs.subscribe(this.userId, sources[this.id], C.WEBRTC, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.3.9",
+  "version": "2.3.10-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.3.9",
+  "version": "2.3.10-dev",
   "private": true,
   "scripts": {
     "start": "node server.js"


### PR DESCRIPTION
The `bitrate` parameter can be passed on `start` calls to the `video` upper-layer process. It's optional.

The prop will be merged with the default conference specs for the `mcs-core` media controller and used accordingly.
I turned subscribers' BW uncapped since we're entering the heteregenous bitrate territory, so it's best I leave that to the browser to handle.