### PR TITLE
v2.3.12

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -1,6 +1,9 @@
 kurento:
   - ip: ""
     url: ws://HOST/kurento
+# Number of attemps of connecting to the configured kurento instances the first
+# time. Infinity means it tries forever until it's able to connect. Default is 10.
+kurentoStartupRetries: 10
 video-transposing-ceiling: 50
 audio-transposing-ceiling: 100
 localIpAddress: ""

--- a/lib/mcs-core/lib/media/balancer.js
+++ b/lib/mcs-core/lib/media/balancer.js
@@ -12,6 +12,8 @@ const VIDEO_TRANSPOSING_CEILING = config.get('video-transposing-ceiling');
 const AUDIO_TRANSPOSING_CEILING = config.get('audio-transposing-ceiling');
 const KMS_FAIL_AFTER = 5;
 const KMS_FAILOVER_TIMEOUT_MS = 15000;
+const NOF_STARTUP_CONNECTION_RETRIES = 5;
+const HOST_RETRY_TIMER = 3000;
 
 let instance = null;
 
@@ -28,26 +30,34 @@ class Balancer extends EventEmitter {
 
   async upstartHosts () {
     const processHosts = async () => {
-      let validHosts = [];
-      for (let i = 0; i < KMS_ARRAY.length; i++) {
-        const { url, ip } = KMS_ARRAY[i];
-        if (!this._hostStarted(url, ip)) {
-          try {
-            const newHost = await Balancer.connectToHost(url, ip);
-            validHosts.push(newHost);
-            this._monitorConnectionState(newHost);
+      const tryToConnect = async (host) => {
+        const { url, ip, mediaType, retries } = host;
+        if (retries < NOF_STARTUP_CONNECTION_RETRIES) {
+          if (!this._hostStarted(url, ip)) {
+            try {
+              const newHost = await Balancer.connectToHost(url, ip, mediaType);
+              this._monitorConnectionState(newHost);
+              this.addHost(newHost);
+            }
+            catch (e) {
+              host.retries++;
+              Logger.error(`[mcs-balancer] Failed to connect to candidate host ${JSON.stringify({ url, ip, retries})}`);
+              setTimeout(() => tryToConnect(host), HOST_RETRY_TIMER);
+            };
           }
-          catch (e) {
-            Logger.error('[mcs-balancer] Failed to connect to candidate host', { url, ip });
-          };
+        } else {
+          Logger.error(`[mcs-balancer] Maximum number of retries expired for host ${url} ${ip}`);
         }
-      }
-      return validHosts;
+      };
+
+      const tentativeHosts = KMS_ARRAY.map(th => { return { ...th, retries: 0}});
+
+      tentativeHosts.forEach(tentativeHost => {
+        tryToConnect(tentativeHost);
+      });
     }
 
-    this.hosts = await processHosts();
-
-    Logger.info('[mcs-balancer] Available hosts =>', this.hosts.map(h => ({ url: h.url })));
+    processHosts();
   }
 
   static connectToHost (url, ip) {
@@ -94,6 +104,7 @@ class Balancer extends EventEmitter {
       const { id } = host;
       this.removeHost(id);
       this.hosts.push(host);
+      Logger.info('[mcs-balancer] Available hosts =>', JSON.stringify(this.hosts.map(h => ({ url: h.url, ip: h.ip, mediaType: h.mediaType }))));
       return;
     }
 
@@ -213,7 +224,7 @@ class Balancer extends EventEmitter {
         } catch (err) {
           Logger.info("[mcs-balancer] Failed to reconnect to host", id);
         }
-      }, 2000);
+      }, HOST_RETRY_TIMER);
     }
   }
 }

--- a/lib/mcs-core/lib/media/balancer.js
+++ b/lib/mcs-core/lib/media/balancer.js
@@ -12,7 +12,9 @@ const VIDEO_TRANSPOSING_CEILING = config.get('video-transposing-ceiling');
 const AUDIO_TRANSPOSING_CEILING = config.get('audio-transposing-ceiling');
 const KMS_FAIL_AFTER = 5;
 const KMS_FAILOVER_TIMEOUT_MS = 15000;
-const NOF_STARTUP_CONNECTION_RETRIES = 5;
+const NOF_STARTUP_CONNECTION_RETRIES = config.has('kurentoStartupRetries')
+  ? config.get('kurentoStartupRetries')
+  : 10;
 const HOST_RETRY_TIMER = 3000;
 
 let instance = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "private": true,
   "scripts": {
     "start": "node server.js"


### PR DESCRIPTION
Backports https://github.com/mconf/bbb-webrtc-sfu/pull/82/ with a pinch of salt to it.

Constitutes patch release v2.3.12.

__CHANGELOG__

- Add first time connection retries between SFU and KMS. Number of retries is configurable with `kurentoStartupRetries`. `Infinity` retries forever until it can connect to it or the server melts. Default is `10`.
