### PR TITLE
Change default kurento.url to ws://127.0.0.1:8888

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -1,6 +1,6 @@
 kurento:
   - ip: ""
-    url: ws://HOST/kurento
+    url: ws://127.0.0.1:8888/kurento
 # Number of attemps of connecting to the configured kurento instances the first
 # time. Infinity means it tries forever until it's able to connect. Default is 10.
 kurentoStartupRetries: 10


### PR DESCRIPTION
After some discussion with @capilkey on how to make this config param less troublesome, I'm changing the default value to something that should almost always work on a normal setup without the need of meddling with it in the packaging scripts.

The packaging/deploy scripts should be reviewed before merging this to get rid of the `HOST` value override on --setip and whatever else does it.