### PR TITLE
 Add timestamp to envelope

### DIFF
--- a/lib/bbb/messages/OutMessage2x.js
+++ b/lib/bbb/messages/OutMessage2x.js
@@ -13,7 +13,8 @@ function OutMessage2x(messageName, routing, headerFields) {
 
     this.envelope = {
       name: messageName,
-      routing: routing 
+      routing: routing,
+      timestamp: Date.now() 
     }
     /**
      * The header template of the message


### PR DESCRIPTION
 - we add a new timestamp field so we can collect statistics on message
   processing times.