### PR TITLE
v2.3.13

### DIFF
--- a/lib/ProcessManager.js
+++ b/lib/ProcessManager.js
@@ -70,8 +70,9 @@ module.exports = class ProcessManager {
     // Tries to restart process on unsucessful exit
     proc.on('exit', (code, signal) => {
       let processId = proc.pid;
-      if (this.runningState === 'RUNNING' && code === 1) {
-        Logger.error('[ProcessManager] Received exit event from child process with PID', proc.pid, ' with code', code, '. Restarting it');
+      if (this.runningState === 'RUNNING' && (code === 1 || signal == 'SIGABRT')) {
+        Logger.error(`[ProcessManager] Received exit event from child process ${processPath} with PID ${proc.pid} Restarting it`,
+          { code, signal, pid: proc.pid, process: processPath});
         this.restartProcess(processId);
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -810,14 +810,14 @@
         "es6-promise": "^4.0.5",
         "extend": "^3.0.0",
         "inherits": "~2.0.3",
-        "kurento-client-core": "git+https://github.com/mconf/kurento-client-core-js.git#mconf",
-        "kurento-client-elements": "git+https://github.com/mconf/kurento-client-elements-js.git#mconf",
-        "kurento-client-filters": "github:Kurento/kurento-client-filters-js#master",
-        "kurento-jsonrpc": "github:Kurento/kurento-jsonrpc-js#master",
+        "kurento-client-core": "git+https://github.com/mconf/kurento-client-core-js.git#3bfcff9cb21430a4f451239100b4c306b9705757",
+        "kurento-client-elements": "git+https://github.com/mconf/kurento-client-elements-js.git#8db04d5a31c299c9c6bacdfbc8fb358ad1c80fbb",
+        "kurento-client-filters": "github:Kurento/kurento-client-filters-js#3cc33e3ad678c8e795aea9678faa6bf184976b64",
+        "kurento-jsonrpc": "github:Kurento/kurento-jsonrpc-js#faa8bae2166538bb82bc46556ce7b84ffab18cd3",
         "minimist": "^1.2.0",
         "promise": "7.1.1",
         "promisecallback": "0.0.4",
-        "reconnect-ws": "github:KurentoForks/reconnect-ws#master"
+        "reconnect-ws": "github:KurentoForks/reconnect-ws#f287385d75861654528c352e60221f95c9209f8a"
       }
     },
     "kurento-client-core": {
@@ -1125,7 +1125,7 @@
       "version": "github:KurentoForks/reconnect-ws#f287385d75861654528c352e60221f95c9209f8a",
       "from": "github:KurentoForks/reconnect-ws#master",
       "requires": {
-        "reconnect-core": "github:KurentoForks/reconnect-core",
+        "reconnect-core": "github:KurentoForks/reconnect-core#921d43e91578abb2fb2613f585c010c1939cf734",
         "websocket-stream": "~0.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-webrtc-sfu",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "private": true,
   "scripts": {
     "start": "node server.js"


### PR DESCRIPTION
Patch release v2.3.13.

__CHANGELOG__:
- Let the process manager autorestart processes on `SIGABRT`. This mitigates an issue where the core process (`mcs-core/process.js`) crashes on 2.3.x due to heap issues by autorestarting it (**aka the infamous 2200 error**). It applies to all processes besides the core one (screenshare, video and audio).