### PR TITLE
Add more termination signals to process-manager restart procedures

### DIFF
--- a/lib/ProcessManager.js
+++ b/lib/ProcessManager.js
@@ -11,6 +11,7 @@ const cp = require('child_process');
 const Logger = require('./utils/Logger');
 const config = require('config');
 const PROCESSES = config.get('processes');
+const UNEXPECTED_TERMINATION_SIGNALS = ['SIGABRT', 'SIGBUS', 'SIGSEGV', 'SIGILL'];
 
 module.exports = class ProcessManager {
   constructor() {
@@ -70,10 +71,16 @@ module.exports = class ProcessManager {
     // Tries to restart process on unsucessful exit
     proc.on('exit', (code, signal) => {
       let processId = proc.pid;
-      if (this.runningState === 'RUNNING' && (code === 1 || signal == 'SIGABRT')) {
-        Logger.error(`[ProcessManager] Received exit event from child process ${processPath} with PID ${proc.pid} Restarting it`,
-          { code, signal, pid: proc.pid, process: processPath});
+      const shouldRestart = this.runningState === 'RUNNING'
+        && (code === 1 || UNEXPECTED_TERMINATION_SIGNALS.includes(signal));
+
+      if (shouldRestart) {
+        Logger.error(`[ProcessManager] Received exit event from child process ${processPath} with PID ${proc.pid}. Restarting it`,
+          { code, signal, pid: proc.pid, process: processPath });
         this.restartProcess(processId);
+      } else {
+        Logger.warn(`[ProcessManager] Received exit event from child process ${processPath} with PID ${proc.pid}. Won't restart.`,
+          { code, signal, pid: proc.pid, process: processPath });
       }
     });
 


### PR DESCRIPTION
Follow up to #43. Add more core dump signals to the process restart procedure.