### PR TITLE
Manually pick some improvements from v2.4.x

### DIFF
--- a/lib/audio/AudioManager.js
+++ b/lib/audio/AudioManager.js
@@ -75,13 +75,15 @@ module.exports = class AudioManager extends BaseManager {
 
     switch (message.id) {
       case 'start':
-        const notifyStartError = (error) => {
-          return this._bbbGW.publish(JSON.stringify({
-            ...error
+      const handleStartError = (errorMessage) => {
+          errorMessage.id = 'webRTCAudioError';
+          this._stopSession(sessionId);
+          this._bbbGW.publish(JSON.stringify({
+            ...errorMessage,
           }), C.FROM_AUDIO);
         }
 
-        Logger.debug(this._logPrefix, 'Received start message', message, 'from connection', message.connectionId);
+        Logger.debug(this._logPrefix, 'Received start message', message, 'from connection', connectionId);
 
         if (session == null) {
           session = new Audio(this._bbbGW, voiceBridge, this.mcs);
@@ -90,8 +92,9 @@ module.exports = class AudioManager extends BaseManager {
           this._sessions[sessionId] = session;
           try {
             await session.upstartSourceAudio(message.sdpOffer, message.caleeName);
-          } catch (err) {
-            return notifyStartError(err);
+          } catch (error) {
+            const errorMessage = this._handleError(this._logPrefix, connectionId, message.calleeName, C.RECV_ROLE, error);
+            return handleStartError(errorMessage);
           }
         }
 
@@ -99,23 +102,20 @@ module.exports = class AudioManager extends BaseManager {
 
         // starts audio session by sending sessionID, websocket and sdpoffer
         session.start(sessionId, connectionId, message.sdpOffer, message.caleeName, message.userId, message.userName, (error, sdpAnswer) => {
-          Logger.info(this._logPrefix, "Started presenter ", sessionId, " for connection", connectionId);
-          Logger.debug(this._logPrefix, "SDP answer was", sdpAnswer);
-
           if (error) {
             const errorMessage = this._handleError(this._logPrefix, connectionId, null, C.RECV_ROLE, error);
-            return notifyStartError(errorMessage);
+            return handleStartError(errorMessage);
           }
+
+          Logger.info(this._logPrefix, "Started presenter ", sessionId, " for connection", connectionId);
+          Logger.debug(this._logPrefix, "SDP answer was", sdpAnswer);
 
           // Empty ice queue after starting audio
           this._flushIceQueue(session, iceQueue);
 
           session.once(C.MEDIA_SERVER_OFFLINE, async (event) => {
             const errorMessage = this._handleError(this._logPrefix, connectionId, message.caleeName, C.RECV_ROLE, errors.MEDIA_SERVER_OFFLINE);
-            errorMessage.id = 'webRTCAudioError';
-            this._bbbGW.publish(JSON.stringify({
-              ...errorMessage,
-            }), C.FROM_AUDIO);
+            return handleStartError(errorMessage);
           });
 
           this._bbbGW.publish(JSON.stringify({

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -26,6 +26,8 @@ module.exports = class Audio extends BaseProvider {
     this._mediaFlowingTimeouts = {};
     this.connectedUsers = {};
     this.candidatesQueue = {}
+    this.handleMCSCoreDisconnection = this.handleMCSCoreDisconnection.bind(this);
+    this.mcs.on(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
   }
 
   onIceCandidate (_candidate, connectionId) {
@@ -339,7 +341,7 @@ module.exports = class Audio extends BaseProvider {
 
   async stop () {
     Logger.info(LOG_PREFIX, 'Releasing endpoints for user', this.userId, 'at room', this.voiceBridge);
-
+    this.mcs.removeListener(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
     try {
       await this.mcs.leave(this.voiceBridge, this.userId);
 

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -329,35 +329,45 @@ module.exports = class Audio extends BaseProvider {
     this.sendUserDisconnectedFromGlobalAudioMessage(id);
 
     if (listener) {
-      try {
-        if (this.audioEndpoints && Object.keys(this.audioEndpoints).length === 1) {
+      if (this.audioEndpoints && Object.keys(this.audioEndpoints).length === 1) {
+        try {
           await this.mcs.leave(this.voiceBridge, this.userId);
-          this.sourceAudioStarted = false;
-          this.sourceAudioStatus = C.MEDIA_STOPPED;
-          this.emit(C.MEDIA_STOPPED, this.voiceBridge);
+        } catch (error) {
+          Logger.warn(LOG_PREFIX, `Error on leave procedure for ${this.voiceBridge}, probably a glare NOT_FOUND`,
+            { error, voiceBridge: this.voiceBridge });
         }
-        else {
+
+        this.sourceAudioStarted = false;
+        this.sourceAudioStatus = C.MEDIA_STOPPED;
+        this.emit(C.MEDIA_STOPPED, this.voiceBridge);
+      } else {
+        try {
           await this.mcs.unsubscribe(this.userId, listener);
+        } catch (error) {
+          Logger.warn(LOG_PREFIX, `Error on unsubscribe procedure for ${listener}, probably a glare NOT_FOUND`,
+            { error, listener});
         }
-
-        delete this.candidatesQueue[id];
-        delete this.audioEndpoints[id];
-
-        return;
       }
-      catch (err) {
-        this._handleError(LOG_PREFIX, err, "recv", userId);
-        return;
-      }
+
+      delete this.candidatesQueue[id];
+      delete this.audioEndpoints[id];
+
+      return;
     }
   }
 
   async stop () {
     Logger.info(LOG_PREFIX, 'Releasing endpoints for user', this.userId, 'at room', this.voiceBridge);
     this.mcs.removeListener(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
+
     try {
       await this.mcs.leave(this.voiceBridge, this.userId);
+    } catch (error) {
+      Logger.warn(LOG_PREFIX, `Error on leave procedure for ${this.voiceBridge}, probably a glare NOT_FOUND`,
+        { error, voiceBridge: this.voiceBridge });
+    }
 
+    try {
       for (var listener in this.audioEndpoints) {
         delete this.audioEndpoints[listener];
       }

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -5,6 +5,8 @@ const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
 const Messaging = require('../bbb/messages/Messaging');
 const BaseProvider = require('../base/BaseProvider');
+const errors = require('../base/errors');
+
 const LOG_PREFIX = "[audio]";
 
 const mediaFlowTimeoutDuration = config.get('mediaFlowTimeoutDuration');
@@ -223,6 +225,12 @@ module.exports = class Audio extends BaseProvider {
       Logger.info("[audio] Upstarting source audio for", this.voiceBridge);
       try {
         if (!this.sourceAudioStarted && this.sourceAudioStatus === C.MEDIA_STOPPED) {
+          const isConnected = await this.mcs.waitForConnection();
+
+          if (!isConnected) {
+            return reject(errors.MEDIA_SERVER_OFFLINE);
+          }
+
           this.userId = await this.mcs.join(this.voiceBridge, 'SFU', {});
           Logger.info(LOG_PREFIX, "MCS join for", this.connectionId, "returned", this.userId);
           const options = {
@@ -254,6 +262,11 @@ module.exports = class Audio extends BaseProvider {
   async start (sessionId, connectionId, sdpOffer, calleeName, userId, userName, callback) {
     try {
       Logger.info(LOG_PREFIX, "Starting audio instance for", { connectionId, userId, userName }, "at", sessionId, this.sourceAudioStatus, this.sourceAudioStarted);
+      const isConnected = await this.mcs.waitForConnection();
+
+      if (!isConnected) {
+        throw errors.MEDIA_SERVER_OFFLINE;
+      }
 
       // Storing the user data to be used by the pub calls
       const user = { userId, userName};

--- a/lib/base/BaseProvider.js
+++ b/lib/base/BaseProvider.js
@@ -110,4 +110,9 @@ module.exports = class BaseProvider extends EventEmitter {
 
     return `${basePath}/${subPath}/${room}/${recordingName}-${timestamp}.${format}`
   }
+
+  handleMCSCoreDisconnection (error) {
+    Logger.error(`[${this.sfuApp}] Provider received a MCS core disconnection event, fire a MEDIA_SERVER_OFFLINE`);
+    this.emit(C.MEDIA_SERVER_OFFLINE);
+  }
 };

--- a/lib/base/MCSAPIWrapper.js
+++ b/lib/base/MCSAPIWrapper.js
@@ -7,6 +7,7 @@ const Logger = require('../utils/Logger');
 const MCS = require('mcs-js');
 const C = require('../bbb/messages/Constants');
 
+const CONNECTION_TIMEOUT = 10000;
 let instance = null;
 
 module.exports = class MCSAPIWrapper extends EventEmitter {
@@ -15,6 +16,7 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
       super();
       this._mcs = null;
       instance = this;
+      this.connected = false;
     }
 
     return instance;
@@ -61,6 +63,7 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
     }
 
     this.emit(C.MCS_CONNECTED);
+    this.connected = true;
     this._connectionResolver();
   }
 
@@ -68,6 +71,7 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
     // TODO base reconenction, should be ane exponential backoff
     if (this._reconnectionRoutine == null) {
       this.emit(C.MCS_DISCONNECTED);
+      this.connected = false;
       this._reconnectionRoutine = setInterval(async () => {
         try {
           Logger.info("[sfu-mcs-api] Connecting to MCS at", this.addr);
@@ -265,6 +269,29 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
 
   setStrategy (strategy) {
     // TODO
+  }
+
+  waitForConnection () {
+    const onConnected = () => {
+      return new Promise((resolve) => {
+        if (this.connected) {
+          return resolve(true);
+        }
+        this.once(C.MCS_CONNECTED, () => {
+          return resolve(true);
+        });
+      });
+    }
+
+    const failOver = () => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          return resolve(false)
+        }, CONNECTION_TIMEOUT);
+      });
+    };
+
+    return Promise.race([onConnected(), failOver()]);
   }
 
   _handleError (error, operation) {

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -51,6 +51,8 @@ module.exports = class Screenshare extends BaseProvider {
     this.recording = {};
     this.isRecorded = false;
     this._recordingSubPath = 'screenshare';
+    this.handleMCSCoreDisconnection = this.handleMCSCoreDisconnection.bind(this);
+    this.mcs.on(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
   }
 
   async onIceCandidate (candidate, role, userId, connectionId) {
@@ -425,9 +427,11 @@ module.exports = class Screenshare extends BaseProvider {
   stop () {
     return new Promise(async (resolve, reject) => {
       try {
+        this.mcs.removeListener(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
         if (this._status === C.MEDIA_STOPPED) {
           return resolve();
         }
+
         Logger.info('[screnshare] Stopping and releasing endpoints for MCS user', this.mcsUserId);
         await this._stopScreensharing();
         // Check if properly started the recording before trying to stop it

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -13,6 +13,7 @@ const Messaging = require('../bbb/messages/Messaging');
 const Logger = require('../utils/Logger');
 const BaseProvider = require('../base/BaseProvider');
 const config = require('config');
+const errors = require('../base/errors');
 const localIpAddress = config.get('localIpAddress');
 const EventEmitter = require('events').EventEmitter;
 const SHOULD_RECORD = config.get('recordScreenSharing');
@@ -223,6 +224,13 @@ module.exports = class Screenshare extends BaseProvider {
   start (sessionId, connectionId, sdpOffer, userId, role) {
     return new Promise(async (resolve, reject) => {
       this._status = C.MEDIA_STARTING;
+
+      const isConnected = await this.mcs.waitForConnection();
+
+      if (!isConnected) {
+        return reject(errors.MEDIA_SERVER_OFFLINE);
+      }
+
       // Probe akka-apps to see if this is to be recorded
       if (SHOULD_RECORD && role === C.SEND_ROLE) {
         this.isRecorded = await this.probeForRecordingStatus(this._meetingId, userId);

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -224,6 +224,12 @@ module.exports = class Video extends BaseProvider {
         this.status = C.MEDIA_STARTING;
 
         try {
+          const isConnected = await this.mcs.waitForConnection();
+
+          if (!isConnected) {
+            return reject(errors.MEDIA_SERVER_OFFLINE);
+          }
+
           // Probe akka-apps to see if this is to be recorded
           if (SHOULD_RECORD && this.shared) {
             this.isRecorded = await this.probeForRecordingStatus(this.meetingId, this.id);

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -34,6 +34,8 @@ module.exports = class Video extends BaseProvider {
     this.notFlowingTimeout = null;
     this.isRecording = false;
     this.pending = false;
+    this.handleMCSCoreDisconnection = this.handleMCSCoreDisconnection.bind(this);
+    this.mcs.on(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
   }
 
   static setSource (userId, stream) {
@@ -356,6 +358,8 @@ module.exports = class Video extends BaseProvider {
 
   async stop () {
     return new Promise(async (resolve, reject) => {
+      this.mcs.removeListener(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
+
       if (this.status === C.MEDIA_STOPPED) {
         Logger.warn(LOG_PREFIX, 'Video session', this.streamName, this.userId, 'at room', this.meetingId, 'already stopped');
         return resolve();


### PR DESCRIPTION
Includes:
  - Stop procedures consistency improvements for audio/video/screenshare modules.
  - Add a connection state to the MCS (core process) API wrapper.
  - Add a connection state probe method to the MCS API Wrapper and use it in audio/video./screenshare components. It'll properly return MEDIA_SERVER_OFFLINE errors if needed.
  - Listen for the MCS API Wrapper DISCONNECTED event and react to it properly in audio/video./screenshare components by sending MEDIA_SERVER_OFFLINE error to clients.