### PR TITLE
Allow Listening to Specific Hosts

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -6,8 +6,11 @@ redisHost: REDIS_HOST
 redisPort: REDIS_PORT
 redisPassword: REDIS_PASSWORD
 
+clientHost: CLIENT_HOST
+
 mcs-port: MCS_PORT
-mcs-address: MCS_HOST
+mcs-host: MCS_HOST
+mcs-address: MCS_ADDRESS
 
 freeswitch:
     ip: FREESWITCH_CONN_IP

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -60,6 +60,7 @@ redisExpireTime: 1209600 # 14 days as per the akka keys
 # mcs-core entrypoint configured on nginx
 mcs-path: /mcs
 mcs-port: 3010
+mcs-host: 0.0.0.0
 mcs-address: localhost
 mcs-ws-timeout: 30000
 freeswitch:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -27,7 +27,7 @@ redisPort: "6379"
 # Uncomment to set a password if Redis requires auth.
 # redisPassword: foobared
 clientPort: "3008"
-clientHost: 0.0.0.0
+clientHost: 127.0.0.1
 minVideoPort: 30000
 maxVideoPort: 33000
 mediaFlowTimeoutDuration: 15000
@@ -60,7 +60,7 @@ redisExpireTime: 1209600 # 14 days as per the akka keys
 # mcs-core entrypoint configured on nginx
 mcs-path: /mcs
 mcs-port: 3010
-mcs-host: 0.0.0.0
+mcs-host: 127.0.0.1
 mcs-address: localhost
 mcs-ws-timeout: 30000
 freeswitch:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -27,6 +27,7 @@ redisPort: "6379"
 # Uncomment to set a password if Redis requires auth.
 # redisPassword: foobared
 clientPort: "3008"
+clientHost: 0.0.0.0
 minVideoPort: 30000
 maxVideoPort: 33000
 mediaFlowTimeoutDuration: 15000

--- a/lib/connection-manager/HttpServer.js
+++ b/lib/connection-manager/HttpServer.js
@@ -13,7 +13,7 @@ module.exports = class HttpServer {
     //const credentials = {key: privateKey, cert: certificate};
 
     this.port = config.get('clientPort');
-    this.host = config.has('clientHost') ? config.get('clientHost') : '0.0.0.0';
+    this.host = config.has('clientHost') ? config.get('clientHost') : '127.0.0.1';
 
     this.server = http.createServer((req,res) => {
     }).on('error', this.handleError.bind(this))

--- a/lib/connection-manager/HttpServer.js
+++ b/lib/connection-manager/HttpServer.js
@@ -13,6 +13,7 @@ module.exports = class HttpServer {
     //const credentials = {key: privateKey, cert: certificate};
 
     this.port = config.get('clientPort');
+    this.host = config.has('clientHost') ? config.get('clientHost') : '0.0.0.0';
 
     this.server = http.createServer((req,res) => {
     }).on('error', this.handleError.bind(this))
@@ -36,7 +37,7 @@ module.exports = class HttpServer {
 
   listen(callback) {
     Logger.info('[HttpServer] Listening in port ' + this.port);
-    this.server.listen(this.port, callback);
+    this.server.listen(this.port, this.host, callback);
   }
 
 }

--- a/lib/mcs-core/process.js
+++ b/lib/mcs-core/process.js
@@ -16,8 +16,9 @@ class CoreProcess extends BaseProcess {
   startMCSServer () {
     // HTTPS server
     const port = config.get('mcs-port');
+    const host = config.has('mcs-host') ? config.get('mcs-host') : '0.0.0.0';
     const connectionTimeout = config.get('mcs-ws-timeout');
-    const serverHttps = http.createServer().listen(port, () => {
+    const serverHttps = http.createServer().listen(port, host, () => {
       Logger.info('[app] MCS Server is ready to receive connections');
     });
 

--- a/lib/mcs-core/process.js
+++ b/lib/mcs-core/process.js
@@ -16,7 +16,7 @@ class CoreProcess extends BaseProcess {
   startMCSServer () {
     // HTTPS server
     const port = config.get('mcs-port');
-    const host = config.has('mcs-host') ? config.get('mcs-host') : '0.0.0.0';
+    const host = config.has('mcs-host') ? config.get('mcs-host') : '127.0.0.1';
     const connectionTimeout = config.get('mcs-ws-timeout');
     const serverHttps = http.createServer().listen(port, host, () => {
       Logger.info('[app] MCS Server is ready to receive connections');


### PR DESCRIPTION
This patch allows to listen to a specific host only.

For example, when BigBlueButton is used behind Nginx as reverse Proxy,
it is completely sufficient to listen to 127.0.0.1 only, but right now
there is now easy way to configure that.

Note that this patch does not change the default and still works with
the previous configuration making updates easy.