### PR TITLE
[audio] Enrich user validation to avoid interpreting empty strings as invalid usernames

### DIFF
--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -116,7 +116,7 @@ module.exports = class Audio extends BaseProvider {
   };
 
   static isValidUser (user) {
-    return user && user.userId && user.userName;
+    return (typeof user === 'object') && (typeof user.userId === 'string') && (typeof user.userName === 'string');
   }
 
   /**


### PR DESCRIPTION
Some botched sanitation were triggering a weird side effect that dropped the global_audio bridge. This is a quick fix for it.