### PR TITLE
Latest v2.4.x developments

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -93,6 +93,10 @@ kurentoAllowMDNSCandidates:
   __name: KURENTO_ALLOW_MDNS
   __format: json
 
+kurentoTrackIceStateChanges:
+  __name: KURENTO_TRACK_ICE_STATE_CHANGES
+  __format: json
+
 mediaThresholds:
   global: GLOBAL_MEDIA_THRESHOLD
   perRoom: ROOM_MEDIA_THRESHOLD

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -29,8 +29,11 @@ freeswitch:
       __format: json
 
 log:
-    level: LOG_LEVEL
-    filename: LOG_FILENAME
+  level: LOG_LEVEL
+  filename: LOG_FILENAME
+  stdout:
+    __name: LOG_STDOUT_ENABLED
+    __format: json
 
 bbb-stream:
   image_name: STREAM_IMAGE_NAME

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -15,6 +15,9 @@ kurento:
 kurentoStartupRetries: Infinity
 # Whether to allow Kurento to process mDNS ICE candidates
 kurentoAllowMDNSCandidates: true
+# Whether to track KMS's ICE state changes for every peer.
+# Disabled by default for now until we trace the perf. impact of it
+kurentoTrackIceStateChanges: false
 # balancing-strategy: can be either ROUND_ROBIN or MEDIA_TYPE. The MEDIA_TYPE only
 # works properly if you annotated the configured kurento instances in the
 # 'kurento' config parameter with a mediaType field (main|audio|content) which

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -78,7 +78,8 @@ freeswitch:
     public:
 log:
   filename: /var/log/bbb-webrtc-sfu/bbb-webrtc-sfu.log
-  level: verbose
+  level: info
+  stdout: true
 processes:
 - path: ./lib/mcs-core/process.js
 - path: ./lib/screenshare/ScreenshareProcess

--- a/lib/ProcessManager.js
+++ b/lib/ProcessManager.js
@@ -8,10 +8,13 @@
 'use strict';
 
 const cp = require('child_process');
-const Logger = require('./utils/Logger');
+const Logger = require('./utils/Logger.js');
 const config = require('config');
 const PROCESSES = config.get('processes');
+
 const UNEXPECTED_TERMINATION_SIGNALS = ['SIGABRT', 'SIGBUS', 'SIGSEGV', 'SIGILL'];
+const LOG_PREFIX = '[ProcessManager]';
+const PROCESS_RESPAWN_DELAY = 3000;
 
 module.exports = class ProcessManager {
   constructor() {
@@ -39,10 +42,10 @@ module.exports = class ProcessManager {
 
     process.on('uncaughtException', async (error) => {
       if (error.code === 'EADDRINUSE') {
-        Logger.info("[ProcessManager] There's probably another master SFU instance running, keep this one as slave");
+        Logger.info(LOG_PREFIX, "There's probably another master SFU instance running, keep this one as slave");
         return;
       }
-      Logger.error('[ProcessManager] Uncaught exception', error.stack);
+      Logger.error(LOG_PREFIX, "CRITICAL: uncaught exception, shutdown", { error: error.stack });
       await this.finishChildProcesses();
       process.exit('1');
     });
@@ -50,12 +53,12 @@ module.exports = class ProcessManager {
     // Added this listener to identify unhandled promises, but we should start making
     // sense of those as we find them
     process.on('unhandledRejection', (reason, p) => {
-      Logger.error('[ProcessManager] Unhandled Rejection at: Promise', p, 'reason:', reason);
+      Logger.error(LOG_PREFIX, "CRITICAL: Unhandled promise rejection", { reason: reason.toString() });
     });
   }
 
   startProcess (processPath) {
-    Logger.info("[ProcessManager] Starting process at path", processPath);
+    Logger.info(LOG_PREFIX, "Forking process", processPath);
     let proc = cp.fork(processPath, {
       // Pass over all of the environment.
       env: process.ENV,
@@ -75,11 +78,11 @@ module.exports = class ProcessManager {
         && (code === 1 || UNEXPECTED_TERMINATION_SIGNALS.includes(signal));
 
       if (shouldRestart) {
-        Logger.error(`[ProcessManager] Received exit event from child process ${processPath} with PID ${proc.pid}. Restarting it`,
+        Logger.error(LOG_PREFIX, "Received exit event from child process, restarting it",
           { code, signal, pid: proc.pid, process: processPath });
         this.restartProcess(processId);
       } else {
-        Logger.warn(`[ProcessManager] Received exit event from child process ${processPath} with PID ${proc.pid}. Won't restart.`,
+        Logger.warn(LOG_PREFIX, "Received final exit event from child process, process shutdown",
           { code, signal, pid: proc.pid, process: processPath });
       }
     });
@@ -90,21 +93,22 @@ module.exports = class ProcessManager {
   restartProcess (pid) {
     let proc = this.processes[pid];
     if (proc) {
-      let newProcess = this.startProcess(proc.path);
-      this.processes[newProcess.pid] = newProcess;
-      delete this.processes[pid];
+      setTimeout(() => {
+        let newProcess = this.startProcess(proc.path);
+        this.processes[newProcess.pid] = newProcess;
+        delete this.processes[pid];
+      }, PROCESS_RESPAWN_DELAY);
     }
   }
 
   onMessage (message) {
-    Logger.info('[ProcessManager] Received child message from', this.pid, message);
+    Logger.info(LOG_PREFIX, "Received message from forked process",
+      { pid: this.pid, message });
   }
 
-  onError (e) {
-    Logger.error('[ProcessManager] Received child error', this.pid, e);
-  }
-
-  onDisconnect (e) {
+  onError (error) {
+    Logger.error(LOG_PREFIX, "Forked process error event",
+      { pid: this.pid, errorMessage: error.message, errorName: error.name, errorCode: error.code });
   }
 
   async finishChildProcesses () {

--- a/lib/bbb/pubsub/RedisWrapper.js
+++ b/lib/bbb/pubsub/RedisWrapper.js
@@ -13,6 +13,8 @@ const Constants = require('../messages/Constants.js');
 const EventEmitter = require('events').EventEmitter;
 const Logger = require('../../utils/Logger');
 
+const LOG_PREFIX = "[RedisWrapper]";
+
 /* Public members */
 
 module.exports = class RedisWrapper extends EventEmitter {
@@ -45,9 +47,8 @@ module.exports = class RedisWrapper extends EventEmitter {
   }
 
   startSubscriber () {
-    let self = this;
     if (this.redisCli) {
-      Logger.warn("[RedisWrapper] Redis Client already exists");
+      Logger.warn(LOG_PREFIX, "Redis Client already exists.");
       return;
     }
 
@@ -65,28 +66,32 @@ module.exports = class RedisWrapper extends EventEmitter {
     });
 
     this.redisCli.on("error", (error) => {
-      Logger.error("[RedisWrapper] Wrapper returned an error", error);
+      Logger.error(LOG_PREFIX, "Redis client error event", {
+        errorMessage: error.message,
+      });
     });
 
-    this.redisCli.on("reconnecting", (msg) => {
-      Logger.warn("[RedisWrapper] Wrapper instance is reconnecting", msg);
+    this.redisCli.on("reconnecting", (event) => {
+      Logger.warn(LOG_PREFIX, "Redis client reconnecting", { event });
       //TODO
     });
 
     this.redisCli.on("psubscribe", (channel, count) => {
-      Logger.info("[RedisWrapper] Successfully subscribed to pattern [" + channel + "]");
+      Logger.debug(LOG_PREFIX, `Redis client subscribed to channel ${channel}`);
     });
 
     this.redisCli.on("pmessage", this._onMessage.bind(this));
 
     if (!this.subpattern) {
-      throw new Error("[RedisWrapper] No subscriber pattern");
+      throw new Error("INVALID_CHANNEL");
     }
 
     this.redisCli.psubscribe(this.subpattern);
 
-    Logger.info("[RedisWrapper] Started Redis client at " + options.host + ":" + options.port +
-        " for subscription pattern: " + this.subpattern);
+    Logger.debug(LOG_PREFIX, "Redis client started", {
+      host: options.host,
+      port: options.port,
+    });
   }
 
   stopRedis (callback) {

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -14,6 +14,7 @@ const util = require('util');
 const EventEmitter = require('events').EventEmitter;
 const Logger = require('../../utils/Logger');
 
+const LOG_PREFIX = "[bbb-gw]";
 let instance = null;
 
 module.exports = class BigBlueButtonGW extends EventEmitter {
@@ -46,11 +47,21 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
     try {
       wrobj.startSubscriber();
       wrobj.on(C.REDIS_MESSAGE, this.incomingMessage.bind(this));
-      Logger.info("[BigBlueButtonGW] Added redis client to this.subscribers[" + channel + "]");
       return Promise.resolve(wrobj);
+    } catch (error) {
+      Logger.error(LOG_PREFIX, "Redis channel subscribe failed", { channel, errorMessage: error.message });
+      return Promise.reject(error);
     }
-    catch (error) {
-      return Promise.reject("[BigBlueButtonGW] Could not start redis client for channel " + channel);
+  }
+
+  deserialize (message) {
+    if (typeof message === 'object') return message;
+    try {
+      const dmsg = JSON.parse(message);
+      return dmsg;
+    } catch (error) {
+      Logger.error(LOG_PREFIX, "Failed to deserialize message, use it raw", { errorMessage: error.message });
+      return dmsg;
     }
   }
 
@@ -61,17 +72,16 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
    * @param {Object} message  Redis message
    */
   incomingMessage (message) {
+    let meetingId;
     let header;
     let payload;
-    let msg = (typeof message !== 'object')?JSON.parse(message):message;
-    let meetingId;
 
+    const msg = this.deserialize(message);
     // Trying to parse both message types, 1x and 2x
     if (msg.header) {
       header = msg.header;
       payload = msg.payload;
-    }
-    else if (msg.core) {
+    } else if (msg.core) {
       header = msg.core.header;
       payload = msg.core.body;
     }
@@ -133,8 +143,7 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
         default:
           this.emit(C.GATEWAY_MESSAGE, msg);
       }
-    }
-    else {
+    } else {
       this.emit(C.GATEWAY_MESSAGE, msg);
     }
   }
@@ -149,13 +158,11 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
 
   setKey(key, message, callback) {
     this.checkPublisher();
-
     this.publisher.setKey(key, message, callback);
   }
 
   getKey(key, callback) {
     this.checkPublisher();
-
     this.publisher.getKey(key, callback);
   }
 
@@ -166,12 +173,20 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
     let recKey = 'recording:' + meetingId;
 
     this.publisher.setKeyWithIncrement(recKey, message, (err, msgId) => {
-
       this.publisher.pushToList('meeting:' + meetingId + ':recordings', msgId);
+      this.publisher.expireKey(recKey + ':' + msgId, EXPIRE_TIME, (error) => {
+        if (error) {
+          return Logger.error(LOG_PREFIX, 'Recording key Redis write failed', {
+            errorMessage: error.message,
+            meetingId,
+          });
+        }
 
-      // Not implemented yet
-      this.publisher.expireKey(recKey + ':' + msgId, EXPIRE_TIME, (err) => {
-        Logger.info('Recording key will expire in', EXPIRE_TIME, 'seconds', err);
+        Logger.debug(LOG_PREFIX, 'Recording key written in redis', {
+          messageId: msgId,
+          key: recKey,
+          expireTime: EXPIRE_TIME,
+        });
       });
     });
   }

--- a/lib/connection-manager/ConnectionManager.js
+++ b/lib/connection-manager/ConnectionManager.js
@@ -13,14 +13,13 @@ const BigBlueButtonGW = require('../bbb/pubsub/bbb-gw');
 const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
 
+const LOG_PREFIX = '[ConnectionManager]';
+
 // Global variables
 module.exports = class ConnectionManager {
-
   constructor (settings, logger) {
-    this._screenshareSessions = {};
-
+    this._bbbGW;
     this._setupBBB();
-
     this._emitter = this._setupEventEmitter();
     this._adapters = [];
   }
@@ -39,19 +38,18 @@ module.exports = class ConnectionManager {
   }
 
   _setupEventEmitter() {
-    let self = this;
-    let emitter = new EventEmitter();
+    const emitter = new EventEmitter();
 
     emitter.on(C.WEBSOCKET_MESSAGE, (data) => {
       switch (data.type) {
         case "screenshare":
-          self._bbbGW.publish(JSON.stringify(data), C.TO_SCREENSHARE);
+          this._bbbGW.publish(JSON.stringify(data), C.TO_SCREENSHARE);
           break;
         case "video":
-          self._bbbGW.publish(JSON.stringify(data), C.TO_VIDEO);
+          this._bbbGW.publish(JSON.stringify(data), C.TO_VIDEO);
           break;
         case "audio":
-          self._bbbGW.publish(JSON.stringify(data), C.TO_AUDIO);
+          this._bbbGW.publish(JSON.stringify(data), C.TO_AUDIO);
           break;
         case "default":
           // TODO handle API error message;
@@ -61,6 +59,11 @@ module.exports = class ConnectionManager {
     return emitter;
   }
 
+  // Push data to client
+  pushMessage (data) {
+    this._emitter.emit('response', data);
+  }
+
   async _setupBBB() {
     this._bbbGW = new BigBlueButtonGW();
 
@@ -68,22 +71,19 @@ module.exports = class ConnectionManager {
       const screenshare = await this._bbbGW.addSubscribeChannel(C.FROM_SCREENSHARE);
       const video = await this._bbbGW.addSubscribeChannel(C.FROM_VIDEO);
       const audio = await this._bbbGW.addSubscribeChannel(C.FROM_AUDIO);
+      const push = this.pushMessage.bind(this);
 
-      const emitFunk = (data) => {
-        this._emitter.emit('response', data);
-      };
+      screenshare.on(C.REDIS_MESSAGE, push);
+      video.on(C.REDIS_MESSAGE, push);
+      audio.on(C.REDIS_MESSAGE, push);
 
-      screenshare.on(C.REDIS_MESSAGE, emitFunk);
-      video.on(C.REDIS_MESSAGE, emitFunk);
-      audio.on(C.REDIS_MESSAGE, (data) => {
-        this._emitter.emit('response', data);
+      Logger.info(LOG_PREFIX, 'Successfully subscribed to processes redis channels');
+    } catch (error) {
+      Logger.error(LOG_PREFIX, 'Failed to setup connection adapters', {
+        errorMessage: error.message,
+        errorName: error.name,
       });
-
-      Logger.info('[ConnectionManager] Successfully subscribed to processes redis channels');
-    }
-    catch (err) {
-      Logger.info('[ConnectionManager] ' + err);
-      this._stopAll;
+      throw error;
     }
   }
 

--- a/lib/connection-manager/WebsocketConnectionManager.js
+++ b/lib/connection-manager/WebsocketConnectionManager.js
@@ -3,9 +3,7 @@
 const ws = require('ws');
 const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
-
-// ID counter
-let connectionIDCounter = 0;
+const { v4: uuidv4 }= require('uuid');
 
 module.exports = class WebsocketConnectionManager {
   constructor (server, path) {
@@ -42,7 +40,7 @@ module.exports = class WebsocketConnectionManager {
   }
 
   _onNewConnection (ws) {
-    ws.id = connectionIDCounter++;
+    ws.id = uuidv4();
     this.webSockets[ws.id] = ws;
     Logger.info("[WebsocketConnectionManager] New connection with id [ " + ws.id + " ]");
 

--- a/lib/connection-manager/WebsocketConnectionManager.js
+++ b/lib/connection-manager/WebsocketConnectionManager.js
@@ -5,6 +5,8 @@ const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
 const { v4: uuidv4 }= require('uuid');
 
+const LOG_PREFIX = '[WebsocketConnectionManager]';
+
 module.exports = class WebsocketConnectionManager {
   constructor (server, path) {
     this.wss = new ws.Server({
@@ -23,15 +25,18 @@ module.exports = class WebsocketConnectionManager {
   }
 
   _onServerResponse (data) {
-    // Here this is the 'ws' instance
     const connectionId = data? data.connectionId : null;
     const ws = this.webSockets[connectionId];
     if (ws) {
       if (data.id === 'close') {
         try {
           ws.close();
-        } catch (err) {
-          Logger.warn('[WebsocketConnectionManager] Error on closing WS for', connectionId,  err)
+        } catch (error) {
+          Logger.error(LOG_PREFIX, 'WS close failed', {
+            connectionId,
+            errorMessage: error.message,
+            errorCode: error.code
+          });
         }
       } else {
         this.sendMessage(ws, data);
@@ -42,18 +47,18 @@ module.exports = class WebsocketConnectionManager {
   _onNewConnection (ws) {
     ws.id = uuidv4();
     this.webSockets[ws.id] = ws;
-    Logger.info("[WebsocketConnectionManager] New connection with id [ " + ws.id + " ]");
+    Logger.info(LOG_PREFIX, "WS connection opened", { connectionId: ws.id });
 
     ws.on('message', (data) => {
       this._onMessage(ws, data);
     });
 
-    ws.on('close', (err) => {
-      this._onClose(ws, err);
+    ws.on('close', (error) => {
+      this._onClose(ws, error);
     });
 
-    ws.on('error', (err) => {
-      this._onError(ws, err);
+    ws.on('error', (error) => {
+      this._onError(ws, error);
     });
   };
 
@@ -64,8 +69,7 @@ module.exports = class WebsocketConnectionManager {
       message = JSON.parse(data);
 
       if (message.id === 'ping') {
-        this.sendMessage(ws, {id: 'pong'});
-        return;
+        return this.sendMessage(ws, { id: 'pong' });
       }
 
       message.connectionId = ws.id;
@@ -82,19 +86,27 @@ module.exports = class WebsocketConnectionManager {
         ws.role = message.role;
       }
     } catch(e) {
-      Logger.error("  [WebsocketConnectionManager] JSON message parse error " + e);
+      Logger.error(LOG_PREFIX, "JSON message parse failed", {
+        errorMessage: error.message, errorCode: error.code
+      });
       message = {};
     }
 
     // Test for empty or invalid JSON
+    // FIXME yuck, maybe this should be reviewed. - prlanzarin
     if (Object.getOwnPropertyNames(message).length !== 0) {
       this.emitter.emit(C.WEBSOCKET_MESSAGE, message);
     }
   }
 
-  _onError (ws, err) {
-    Logger.debug('[WebsocketConnectionManager] Connection error [' + ws.id + ']', err);
-    let message = {
+  _onError (ws, error) {
+    Logger.debug(LOG_PREFIX, "WS error event", {
+      connectionId: ws.id || 'unknown',
+      errorMessage: error.message,
+      errorCode: error.code
+    });
+
+    const message = {
       id: 'error',
       type: ws.route,
       role: ws.role,
@@ -107,9 +119,10 @@ module.exports = class WebsocketConnectionManager {
     delete this.webSockets[ws.id];
   }
 
-  _onClose (ws, err) {
-    Logger.info('[WebsocketConnectionManager] Closed connection on [' + ws.id + ']');
-    let message = {
+  _onClose (ws) {
+    Logger.info(LOG_PREFIX, "WS connection closed", { connectionId: ws.id });
+
+    const message = {
       id: 'close',
       type: ws.route,
       role: ws.role,
@@ -123,17 +136,23 @@ module.exports = class WebsocketConnectionManager {
   }
 
   sendMessage (ws, json) {
-
     if (ws._closeCode === 1000) {
-      Logger.error("[WebsocketConnectionManager] Websocket closed, not sending");
-      this._onError(ws, "[WebsocketConnectionManager] Error: not opened");
+      Logger.error(LOG_PREFIX, "WS is closed, won't send message", {
+        connectionId: ws ? ws.id : 'unknown',
+        requestId: json.id,
+      });
+      this._onError(ws, new Error('WS closed'));
     }
 
     return ws.send(JSON.stringify(json), (error) => {
-      if(error) {
-        Logger.error('[WebsocketConnectionManager] Websocket error "' + error + '" on message "' + json.id + '"');
+      if (error) {
+        Logger.error(LOG_PREFIX, 'WS send failed', {
+          connectionId: ws ? ws.id : 'unknown',
+          errorMessage: error.message,
+          requestId: json.id,
+        });
 
-        this._onError(ws, error);
+        return this._onError(ws, error);
       }
     });
   }

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -21,6 +21,9 @@ const ALLOWED_CANDIDATE_IPS = config.has('kurentoAllowedCandidateIps')
 const KURENTO_ALLOW_MDNS = config.has('kurentoAllowMDNSCandidates')
   ? config.get('kurentoAllowMDNSCandidates')
   : false;
+const KURENTO_TRACK_ICE_STATE_CHANGES = config.has('kurentoTrackIceStateChanges')
+  ? config.get('kurentoTrackIceStateChanges')
+  : false;
 const LOG_PREFIX = "[mcs-kurento-adapter]";
 const VANILLA_GATHERING_TIMEOUT = 30000;
 
@@ -1003,8 +1006,10 @@ module.exports = class Kurento extends EventEmitter {
         this.addMediaEventListener(C.EVENT.MEDIA_STATE.FLOW_OUT, elementId);
         this.addMediaEventListener(C.EVENT.MEDIA_STATE.ICE, elementId);
         this.addMediaEventListener(C.EVENT.MEDIA_STATE.ICE_GATHERING_DONE, elementId);
-        //this.addMediaEventListener(C.EVENT.MEDIA_STATE.ICE_STATE_CHANGE, elementId);
         this.addMediaEventListener(C.EVENT.MEDIA_STATE.ICE_CANDIDATE_PAIR_SELECTED, elementId);
+        if (KURENTO_TRACK_ICE_STATE_CHANGES) {
+          this.addMediaEventListener(C.EVENT.MEDIA_STATE.ICE_STATE_CHANGE, elementId);
+        }
         break;
 
       case C.MEDIA_TYPE.RTP:

--- a/lib/mcs-core/lib/utils/logger.js
+++ b/lib/mcs-core/lib/utils/logger.js
@@ -5,7 +5,7 @@ const Logger = new Winston.Logger();
 const config = require('config');
 
 const LOG_CONFIG = config.get('log') || {};
-const { level, filename } = LOG_CONFIG;
+const { level, filename, stdout = true } = LOG_CONFIG;
 const COLORIZE = process.env.NODE_ENV !== 'production';
 
 Logger.configure({
@@ -20,17 +20,18 @@ Logger.configure({
   },
 });
 
-Logger.add(Winston.transports.Console, {
-  timestamp:true,
-  prettyPrint: false,
-  humanReadableUnhandledException: true,
-  colorize: COLORIZE,
-  handleExceptions: false,
-  silent: false,
-  stringify: (obj) => JSON.stringify(obj),
-  level,
-});
-
+if (stdout) {
+  Logger.add(Winston.transports.Console, {
+    timestamp:true,
+    prettyPrint: false,
+    humanReadableUnhandledException: true,
+    colorize: COLORIZE,
+    handleExceptions: false,
+    silent: false,
+    stringify: (obj) => JSON.stringify(obj),
+    level,
+  });
+}
 
 if (filename) {
   Logger.add(Winston.transports.File, {

--- a/lib/utils/Logger.js
+++ b/lib/utils/Logger.js
@@ -5,7 +5,7 @@ const Logger = new Winston.Logger();
 const config = require('config');
 
 const LOG_CONFIG = config.get('log') || {};
-const { level, filename } = LOG_CONFIG;
+const { level, filename, stdout = true } = LOG_CONFIG;
 const COLORIZE = process.env.NODE_ENV !== 'production';
 
 Logger.configure({
@@ -20,16 +20,18 @@ Logger.configure({
   },
 });
 
-Logger.add(Winston.transports.Console, {
-  timestamp:true,
-  prettyPrint: false,
-  humanReadableUnhandledException: true,
-  colorize: COLORIZE,
-  handleExceptions: false,
-  silent: false,
-  stringify: (obj) => JSON.stringify(obj),
-  level,
-});
+if (stdout) {
+  Logger.add(Winston.transports.Console, {
+    timestamp:true,
+    prettyPrint: false,
+    humanReadableUnhandledException: true,
+    colorize: COLORIZE,
+    handleExceptions: false,
+    silent: false,
+    stringify: (obj) => JSON.stringify(obj),
+    level,
+  });
+}
 
 
 if (filename) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,6 +294,13 @@
         "eventemitter2": "^4.1",
         "uuid": "^3.1.0",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "nan": {
@@ -483,9 +490,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "websocket-stream": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "sdp-transform": "2.13.0",
     "sip.js": "git+https://github.com/mconf/sip.js.git#v0.7.5.10",
     "winston": "2.4.5",
-    "ws": "7.3.1"
+    "ws": "7.3.1",
+    "uuid": "8.3.1"
   },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
### What does this PR do?
  - connection-manager: SFU WebSocket connection IDs are now UUIDs (v4)
  - logging: add an option to disable stdout logging
    * Allows to choose to log only to files. Currently logs to both stdout and file by default, which is redudant
    * Flag is `log.stdout`/`LOG_STDOUT_ENABLED`, `true|false`
  - logging: cleanups: redis-wrapper, bbb-gw, process-manager, connection-manager
  - connection-manager: fix a rare edge case with error handling when setting up inbound Redis clients in the main process
  - process-manager: add process respawn interval
    * Avoids a process forking spiral when server gets OOM'ed tto hell or something botched one of the children processes
  - kurento: add flag to toggle ICE state change tracking
    * Enable it mainly generates logs about every peer ICE state transitions in the server
    * Disabled by default while I assess any performance impact due to enabling it
    * If it works ok, I'll use it in the future to harden derelict endpoint cleanups
    * `kurentoTrackIceStateChanges`/`KURENTO_TRACK_ICE_STATE_CHANGES`, `true|false`
