### PR TITLE
kurento: disable mDNS candidates by default

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -14,7 +14,7 @@ kurento:
 # time. Infinity means it tries forever until it's able to connect. Default is Infinity.
 kurentoStartupRetries: Infinity
 # Whether to allow Kurento to process mDNS ICE candidates
-kurentoAllowMDNSCandidates: true
+kurentoAllowMDNSCandidates: false
 # Whether to track KMS's ICE state changes for every peer.
 # Disabled by default for now until we trace the perf. impact of it
 kurentoTrackIceStateChanges: false


### PR DESCRIPTION
Commit 377435c (v2.4.23) enabled mDNS processing by default.
This was a decision I made myself after testing it in a simulated intranet AND load testing it in regular setups.

Seeing that it worked with no apparent drawbacks, I enabled them. It seems, though, that enabling it causes stalls in Kurento
processing pipelines earlier than expected. That effectively reduces Kurento's capacity by a fair margin due to something related 
to unresolvable DNS queries stalling the reduced pool of threads Kurento uses for such stuff.

We've only seen that happen in one specific cloud provider. It's not generalized. But I'm reverting it to disabled by default until we
figure out what's up.