### PR TITLE
screenshare: screensharePlayStartEnabled true by default

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -38,7 +38,7 @@ requestQueueTimeout: 15000
 screenshareKeyframeInterval: 0
 screenshareEnableFlashRTPBridge: false
 screenshareSubscriberSpecSlave: false
-screensharePlayStartEnabled: false
+screensharePlayStartEnabled: true
 screenshareServerSideAkkaBroadcast: true
 videoSubscriberSpecSlave: false
 


### PR DESCRIPTION
Make the screensharePlayStartEnabled flag true by default. New signaling event needed by the refactored screen sharing client implementation (2.3).