### PR TITLE
Load adpters on boot, server-initiated SDP exchange support, configurable media servers, ...

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -111,3 +111,7 @@ ejectOnUserLeft:
 permissionProbes:
   __name: PERMISSION_PROBES
   __format: json
+
+videoMediaServer: VIDEO_MEDIA_SERVER
+screenshareMediaServer: SCREENSHARE_MEDIA_SERVER
+audioMediaServer: AUDIO_MEDIA_SERVER

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -41,6 +41,9 @@ screenshareSubscriberSpecSlave: false
 screensharePlayStartEnabled: false
 screenshareServerSideAkkaBroadcast: true
 videoSubscriberSpecSlave: false
+videoMediaServer: Kurento
+screenshareMediaServer: Kurento
+audioMediaServer: Kurento
 
 recordScreenSharing: true
 recordWebcams: true

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -14,6 +14,7 @@ const GLOBAL_AUDIO_CONNECTION_TIMEOUT = config.get('mediaFlowTimeoutDuration');
 const MEDIA_FLOW_TIMEOUT_DURATION = config.get('mediaFlowTimeoutDuration');
 const MEDIA_STATE_TIMEOUT_DURATION = config.get('mediaStateTimeoutDuration');
 const PERMISSION_PROBES = config.get('permissionProbes');
+const AUDIO_MEDIA_SERVER = config.get('audioMediaServer');
 
 const EventEmitter = require('events');
 
@@ -534,7 +535,7 @@ module.exports = class Audio extends BaseProvider {
           // act as the RTP relay which will generate the answer descripto for
           // the endpoint published above
           const proxyOptions = {
-            adapter: 'Kurento',
+            adapter: AUDIO_MEDIA_SERVER,
             descriptor: answer,
             name: `PROXY_${this.globalAudioBridge}|subscribe`,
             ignoreThresholds: true,
@@ -653,7 +654,7 @@ module.exports = class Audio extends BaseProvider {
     const { userId, mcsUserId } = this.getUser(connectionId);
     const options = {
       descriptor: sdpOffer,
-      adapter: 'Kurento',
+      adapter: AUDIO_MEDIA_SERVER,
       name: this._assembleStreamName('subscribe', userId, this.meetingId),
       ignoreThresholds: true,
     }

--- a/lib/mcs-core/lib/adapters/adapter-factory.js
+++ b/lib/mcs-core/lib/adapters/adapter-factory.js
@@ -25,8 +25,9 @@ class AdapterFactory extends EventEmitter {
       CONFIGURED_ADAPTERS.forEach(a => {
         try {
           const { path, name } = a;
-          const adapter = require(`${ADAPTER_PATH_PREFIX}${path}`);
-          this.adapters.push({ adapter, name });
+          const adapterConstructor = require(`${ADAPTER_PATH_PREFIX}${path}`);
+          const instance = new adapterConstructor(name, Balancer);
+          this.adapters.push({ adapter: instance, name });
         } catch (e) {
           Logger.error(LOG_PREFIX, 'Could not add configured adapter', a, e);
         }
@@ -46,14 +47,7 @@ class AdapterFactory extends EventEmitter {
   }
 
   findAdapter (adapterName) {
-    let adapter = null;
-    const adapterObj = this.adapters.find(a => a.name === adapterName);
-    if (adapterObj) {
-      const aConstructor = adapterObj.adapter;
-      adapter = new aConstructor(adapterName, Balancer);
-    }
-
-    return adapter;
+    return this.adapters.find(a => a.name === adapterName);
   }
 
   getAdapters (adapterReq) {

--- a/lib/mcs-core/lib/adapters/adapter-factory.js
+++ b/lib/mcs-core/lib/adapters/adapter-factory.js
@@ -47,7 +47,13 @@ class AdapterFactory extends EventEmitter {
   }
 
   findAdapter (adapterName) {
-    return this.adapters.find(a => a.name === adapterName);
+    let adapter = null;
+    const adapterObj = this.adapters.find(a => a.name === adapterName);
+    if (adapterObj) {
+      adapter = adapterObj.adapter;
+    }
+
+    return adapter;
   }
 
   getAdapters (adapterReq) {

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -496,7 +496,7 @@ module.exports = class SDPSession extends MediaSession {
             candidate,
             error: this._handleError(error)
           });
-    
+
           throw error;
         });
       };
@@ -504,7 +504,7 @@ module.exports = class SDPSession extends MediaSession {
     if (this.medias.length === 1) {
       return _add(this.medias[0], candidate);
     }
-    
+
     const { sdpMLineIndex, sdpMid } = candidate;
     if (sdpMLineIndex && this.medias[sdpMLineIndex]) {
       return _add(this.medias[sdpMLineIndex], candidate);
@@ -515,7 +515,7 @@ module.exports = class SDPSession extends MediaSession {
         ...C.ERROR.ICE_CANDIDATE_FAILED,
         details: `Invalid or not found media index`,
       });
-    }    
+    }
   }
 
   getAnswer () {

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -130,6 +130,8 @@ module.exports = class User extends EventEmitter  {
       params.mediaSpecs = source.mediaSpecs;
     }
 
+    params.sourceAdapterElementIds = source.medias.map(m => m.adapterElementId);
+
     try {
       // If there's no source media specs, fetch the source's media specs to
       // make the subscriber match it

--- a/lib/screenshare/screenshare.js
+++ b/lib/screenshare/screenshare.js
@@ -28,6 +28,7 @@ const SCREENSHARE_SERVER_AKKA_BROADCAST = config.has(`screenshareServerSideAkkaB
   ? config.get(`screenshareServerSideAkkaBroadcast`)
   : true;
 const PERMISSION_PROBES = config.get('permissionProbes');
+const SCREENSHARE_MEDIA_SERVER = config.get('screenshareMediaServer');
 
 const LOG_PREFIX = "[screenshare]";
 
@@ -529,6 +530,7 @@ module.exports = class Screenshare extends BaseProvider {
         name: this._assembleStreamName('publish', this.userId, this._voiceBridge),
         mediaProfile: 'content',
         kurentoRembParams,
+        adapter: SCREENSHARE_MEDIA_SERVER,
       };
 
       const { mediaId, answer } = await this.mcs.publish(
@@ -609,6 +611,7 @@ module.exports = class Screenshare extends BaseProvider {
           mediaProfile: 'content',
           mediaSpecSlave: SUBSCRIBER_SPEC_SLAVE,
           kurentoRembParams,
+          adapter: SCREENSHARE_MEDIA_SERVER,
         }
 
         if (this._presenterEndpoint == null) {

--- a/lib/video/VideoManager.js
+++ b/lib/video/VideoManager.js
@@ -220,12 +220,24 @@ module.exports = class VideoManager extends BaseManager {
 
     if (VideoManager.isVideoInstanceReady(video)) {
       video.onIceCandidate(candidate);
-      Logger.debug(this._logPrefix, `Video ICE candidate added`,
+      Logger.debug(this._logPrefix, 'Video ICE candidate added',
         VideoManager.getMetadataFromMessage(message));
     } else {
-      Logger.info(this._logPrefix, `VideoICE candidate queued`,
+      Logger.info(this._logPrefix, 'Video ICE candidate queued',
         VideoManager.getMetadataFromMessage(message));
       iceQueue.push(candidate);
+    }
+  }
+
+  async handleSubscriberAnswer (message) {
+    const { answer } = message;
+    const sessionId = VideoManager.getSessionId(message);
+    const video = this._fetchSession(sessionId);
+
+    try {
+      await video.processAnswer(answer);
+    } catch (error) {
+      console.error(`${this._logPrefix} Answer processing failed`, error);
     }
 
   }
@@ -255,6 +267,10 @@ module.exports = class VideoManager extends BaseManager {
       case 'start':
         queue = this._fetchLifecycleQueue(VideoManager.getSessionId(message));
         queue.push(() => { return this.handleStart(message) });
+        break;
+
+      case 'subscriberAnswer':
+        this.handleSubscriberAnswer(message);
         break;
 
       case 'stop':

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -102,6 +102,15 @@ module.exports = class Video extends BaseProvider {
 
   /* ======= ICE HANDLERS ======= */
 
+  async processAnswer (answer) {
+    const stream = Video.getSource(this.id);
+    try {
+      await this.mcs.subscribe(this.userId, stream, C.WEBRTC, { ...this.options, descriptor: answer, mediaId: this.mediaId });
+    } catch (error) {
+      throw error;
+    }
+  }
+
   async onIceCandidate (_candidate) {
     if (this.mediaId) {
       try {
@@ -500,6 +509,7 @@ module.exports = class Video extends BaseProvider {
         mediaSpecSlave: SUBSCRIBER_SPEC_SLAVE,
         kurentoRembParams,
       }
+      this.options = options;
       const stream = Video.getSource(this.id);
       Logger.info(LOG_PREFIX, `Subscribing to stream ${stream} from user ${this.id}`,
         this._getLogMetadata());

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -16,6 +16,7 @@ const SUBSCRIBER_SPEC_SLAVE = config.has('videoSubscriberSpecSlave')
 const KURENTO_REMB_PARAMS = config.util.cloneDeep(config.get('kurentoRembParams'));
 const EJECT_ON_USER_LEFT = config.get('ejectOnUserLeft');
 const PERMISSION_PROBES = config.get('permissionProbes');
+const VIDEO_MEDIA_SERVER = config.get('videoMediaServer');
 
 let sources = {};
 
@@ -548,6 +549,7 @@ module.exports = class Video extends BaseProvider {
             name: this._assembleStreamName('publish', this.id, this.voiceBridge),
             mediaSpecs,
             kurentoRembParams,
+            adapter: VIDEO_MEDIA_SERVER,
           }
           const { mediaId, answer } = await this.mcs.publish(this.userId, this.voiceBridge, type, options);
           this.mediaId = mediaId;
@@ -586,6 +588,7 @@ module.exports = class Video extends BaseProvider {
         mediaSpecs,
         mediaSpecSlave: SUBSCRIBER_SPEC_SLAVE,
         kurentoRembParams,
+        adapter: VIDEO_MEDIA_SERVER,
       }
       this.options = options;
       const stream = Video.getSource(this.id);


### PR DESCRIPTION
-  Media server adapters: load everything on boot instead of on demand
   * There is no reason to make media server adapter spooling on demand. We better do it as soon as possible to reduce boot time.
- core: propagate list of sources to media server adapters on subscribe calls
- video: add support for server-initiated SDP exchange 
- video, screenshare, audio: make media server adapter configurable 