### PR TITLE
fix(video): always send a broadcast stop cmd to akka-apps on a graceful stop

### DIFF
--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -323,13 +323,22 @@ module.exports = class Video extends BaseProvider {
     }, C.FROM_VIDEO);
   }
 
-  sendPlayStop () {
-    const userCamEvent = Messaging.generateUserCamBroadcastStoppedEventMessage2x(
-      this.meetingId,
-      this.bbbUserId,
-      this.id
-    );
+  sendBroadcastCamStop () {
+    // TODO move parameter checking to the messaging interface
+    if (typeof this.meetingId === 'string'
+      && typeof this.bbbUserId === 'string'
+      && typeof this.id === 'string') {
+      const userCamEvent = Messaging.generateUserCamBroadcastStoppedEventMessage2x(
+        this.meetingId,
+        this.bbbUserId,
+        this.id
+      );
 
+      this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
+    }
+  }
+
+  sendPlayStop () {
     this.sendToClient({
       connectionId: this.connectionId,
       type: 'video',
@@ -338,7 +347,7 @@ module.exports = class Video extends BaseProvider {
       cameraId: this.id,
     }, C.FROM_VIDEO);
 
-    this.bbbGW.publish(userCamEvent, C.TO_AKKA_APPS_CHAN_2x);
+    this.sendBroadcastCamStop();
   }
 
   /* ======= RECORDING METHODS ======= */
@@ -665,6 +674,10 @@ module.exports = class Video extends BaseProvider {
           Logger.error(LOG_PREFIX, `Unsubscribe failed for user ${this.userId} with stream ${this.streamName}`,
             { ...this._getLogMetadata(), error }); }
       }
+    }
+
+    if (this.shared) {
+      this.sendBroadcastCamStop();
     }
 
     if (this.notFlowingTimeout) {


### PR DESCRIPTION
_This is a commit lifted from v2.4.x which was missing in 2.5.x_


-  fix(video): always send a broadcast stop cmd to akka-apps on a graceful stop d61dd63
   * In some specific scenarios streams could be left dangling in akka-apps, but were cleared in HTML5's mongo collections, leaving a webcam sharer in an inconsistent state. This guarantees the stream will be removed from akka-apps whenever there's a graceful shutdown.
   * Comes at the expense of potentially duplicated internal BroadcastStop messages. They're idempotent, so it isn't a big deal. To properly fix this some of the state logic has to be rewritten in multiple components, so this is what works right now