### PR TITLE
change mediasoup default ports

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -256,8 +256,8 @@ mediasoup:
       - "rtp"
       - "rtx"
       - "srtp"
-    rtcMinPort: 8000
-    rtcMaxPort: 11959
+    rtcMinPort: 24577
+    rtcMaxPort: 32768
     #dtlsCertificateFile:
     #dtlsPrivateKeyFile:
   router:


### PR DESCRIPTION
Change mediasoup default port range to equal the defaults settings for
kurento.

Operators would have to change their firewall rules if mediasoup used a
different port range than kurento. This way we enable a seamless upgrade
and prevent support questions on why mediasoup might not work.