### PR TITLE
feat: new module for fullaudio (microphone) communication

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -111,6 +111,7 @@ media-server-adapters:
 videoMediaServer: VIDEO_MEDIA_SERVER
 screenshareMediaServer: SCREENSHARE_MEDIA_SERVER
 audioMediaServer: AUDIO_MEDIA_SERVER
+fullAudioMediaServer: FULL_AUDIO_MEDIA_SERVER
 listenOnlyGlobalAudioMode: GLOBAL_AUDIO_MODE
 
 prometheus:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -48,6 +48,7 @@ videoSubscriberSpecSlave: false
 videoMediaServer: Kurento
 screenshareMediaServer: Kurento
 audioMediaServer: Kurento
+fullAudioMediaServer: Kurento
 # RTP|WebRTC. Dictates how the FS <-> [audioMediaServer] bridge is established:
 # via plain RTP or via a WebRTC-backed RTP stream
 # WebRTC should be used for environments where the bridge is between external

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -128,6 +128,14 @@ modules:
     options:
       # inboundChannel: to-sfu-audio
       # outboundChannel: from-sfu-audio
+- path: ./lib/audio/FullAudioProcess.js
+  name: fullaudio
+  dedicated: true
+  ipc:
+    mode: native
+    options:
+      # inboundChannel: to-sfu-audio
+      # outboundChannel: from-sfu-audio
 # media-server-adapters: path could refer to a npm module
 media-server-adapters:
 - path: kurento/kurento.js

--- a/lib/audio/FullAudioManager.js
+++ b/lib/audio/FullAudioManager.js
@@ -17,8 +17,6 @@ const errors = require('../base/errors');
 const config = require('config');
 const ERRORS = require('../base/errors.js');
 
-const { handleExternalConnections : FS_HANDLE_EXTERNAL_CONNECTIONS }
-  = config.get('freeswitch');
 const EJECT_ON_USER_LEFT = config.get('ejectOnUserLeft');
 const AUDIO_MEDIA_SERVER = config.get('fullAudioMediaServer');
 

--- a/lib/audio/FullAudioManager.js
+++ b/lib/audio/FullAudioManager.js
@@ -9,7 +9,7 @@
 "use strict";
 
 const BigBlueButtonGW = require('../bbb/pubsub/bbb-gw');
-const Audio = require('./audio');
+const Audio = require('./fullaudio');
 const BaseManager = require('../base/BaseManager');
 const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');

--- a/lib/audio/FullAudioManager.js
+++ b/lib/audio/FullAudioManager.js
@@ -71,10 +71,16 @@ module.exports = class AudioManager extends BaseManager {
   // FIXME enqueue stop
   _disconnectAllUsers(meetingId) {
     const sessionId = this._meetings[meetingId];
+    const fullAudioSessions = this._getFullAudioSessionsInMeeting(meetingId);
+
+    fullAudioSessions.forEach((fullAudioSession) => {
+      this._stopSession(fullAudioSession.id);
+    });
+
     if (typeof sessionId !== 'undefined') {
-      const session = this._fetchSession(sessionId);
+      const session = this._fetchSession(connectionId);
       if (session) {
-        Logger.info(this._logPrefix, 'Disconnecting all listen only sessions',
+        Logger.info(this._logPrefix, 'Disconnecting all fullaudio sessions',
           { roomId: sessionId, internalMeetingId: meetingId });
         this._stopSession(sessionId);
       }
@@ -84,6 +90,8 @@ module.exports = class AudioManager extends BaseManager {
 
   _disconnectUser(meetingId, userId) {
     const sessionId = this._meetings[meetingId];
+    const connectionId = session.getConnectionId(userId);
+
     const session = this._fetchSession(sessionId);
     if (session) {
       const connectionId = session.getConnectionId(userId);
@@ -137,6 +145,14 @@ module.exports = class AudioManager extends BaseManager {
     }), C.FROM_AUDIO);
   }
 
+  _getFullAudioSessionsInMeeting (meetingId) {
+    if (!meetingId || !this._sessions) return [];
+
+    return Object.values(this._sessions).filter((session) =>
+      (session.role === "sendrecv") && (session.meetingId === meetingId)
+    );
+  }
+
   async handleStart (message) {
     const {
       connectionId,
@@ -150,13 +166,12 @@ module.exports = class AudioManager extends BaseManager {
       caleeName,
     } = message;
 
-    let session = this._fetchSession(sessionId);
+    let session = this._fetchSession(connectionId);
     const iceQueue = this._fetchIceQueue(this._getReqIdentifier(sessionId, connectionId));
 
-    if (session == null) {
+    if ((session == null) || (role === 'sendrecv')) {
       session = new Audio(this._bbbGW, sessionId, this.mcs, internalMeetingId, mediaServer);
-      this._sessions[sessionId] = {}
-      this._sessions[sessionId] = session;
+      this._sessions[connectionId] = session;
     }
 
     this._meetings[internalMeetingId] = sessionId;
@@ -201,7 +216,7 @@ module.exports = class AudioManager extends BaseManager {
   }
 
   _closeListener (sessionId, connectionId, metadata = {}) {
-    const session = this._fetchSession(sessionId);
+    const session = this._fetchSession(connectionId);
 
     if (session) {
       return session.stopListener(connectionId)
@@ -247,12 +262,11 @@ module.exports = class AudioManager extends BaseManager {
 
   handleSubscriberAnswer (message) {
     const {
-      voiceBridge: sessionId,
       connectionId,
       sdpOffer: answer,
     } = message;
 
-    const session = this._fetchSession(sessionId);
+    const session = this._fetchSession(connectionId);
 
     if (session) {
       const metadata = AudioManager.getMetadataFromMessage(message);
@@ -278,7 +292,7 @@ module.exports = class AudioManager extends BaseManager {
       candidate,
     } = message;
 
-    const session = this._fetchSession(sessionId);
+    const session = this._fetchSession(connectionId);
     const iceQueue = this._fetchIceQueue(this._getReqIdentifier(sessionId, connectionId));
 
     if (session) {

--- a/lib/audio/FullAudioManager.js
+++ b/lib/audio/FullAudioManager.js
@@ -70,22 +70,16 @@ module.exports = class AudioManager extends BaseManager {
 
   // FIXME enqueue stop
   _disconnectAllUsers(meetingId) {
-    const sessionId = this._meetings[meetingId];
     const fullAudioSessions = this._getFullAudioSessionsInMeeting(meetingId);
 
     fullAudioSessions.forEach((fullAudioSession) => {
       this._stopSession(fullAudioSession.id);
     });
 
-    if (typeof sessionId !== 'undefined') {
-      const session = this._fetchSession(connectionId);
-      if (session) {
-        Logger.info(this._logPrefix, 'Disconnecting all fullaudio sessions',
-          { roomId: sessionId, internalMeetingId: meetingId });
-        this._stopSession(sessionId);
-      }
-      delete this._meetings[meetingId];
-    }
+    Logger.info(this._logPrefix, 'Disconnecting all fullaudio sessions',
+      { internalMeetingId: meetingId });
+
+    delete this._meetings[meetingId];
   }
 
   _disconnectUser(meetingId, userId) {

--- a/lib/audio/FullAudioManager.js
+++ b/lib/audio/FullAudioManager.js
@@ -110,7 +110,7 @@ module.exports = class AudioManager extends BaseManager {
   }
 
   _handleSessionWideError (error, sessionId, rawMessage) {
-    Logger.error(this._logPrefix, `Listen only session wide fatal failure`, {
+    Logger.error(this._logPrefix, `Full audio session wide fatal failure`, {
         errorMessage: error.message,
         errorCode: error.code,
         ...AudioManager.getMetadataFromMessage(rawMessage),

--- a/lib/audio/FullAudioManager.js
+++ b/lib/audio/FullAudioManager.js
@@ -57,7 +57,7 @@ module.exports = class AudioManager extends BaseManager {
   async _handleUserJoinedVoiceConf (payload) {
     const { userId, callerName, voiceConf, listenOnly } = payload;
     try {
-      if (FS_HANDLE_EXTERNAL_CONNECTIONS && !listenOnly && userId.startsWith("w_")) {
+      if (!listenOnly && userId.startsWith("w_")) {
         await this.mcs.join(voiceConf, 'SFU', { userId, externalUserId: userId, name: callerName, autoLeave: true });
       }
     } catch (error) {

--- a/lib/audio/FullAudioManager.js
+++ b/lib/audio/FullAudioManager.js
@@ -1,0 +1,326 @@
+/*
+ * Lucas Fialho Zawacki
+ * Paulo Renato Lanzarin
+ * (C) Copyright 2017 Bigbluebutton
+ *
+ */
+
+"use strict";
+
+const BigBlueButtonGW = require('../bbb/pubsub/bbb-gw');
+const Audio = require('./audio');
+const BaseManager = require('../base/BaseManager');
+const C = require('../bbb/messages/Constants');
+const Logger = require('../utils/Logger');
+const errors = require('../base/errors');
+const config = require('config');
+const ERRORS = require('../base/errors.js');
+
+const { handleExternalConnections : FS_HANDLE_EXTERNAL_CONNECTIONS } = config.get('freeswitch');
+const EJECT_ON_USER_LEFT = config.get('ejectOnUserLeft');
+const AUDIO_MEDIA_SERVER = config.get('audioMediaServer');
+
+module.exports = class AudioManager extends BaseManager {
+  constructor (connectionChannel, additionalChannels, logPrefix) {
+    super(connectionChannel, additionalChannels, logPrefix);
+    this.sfuApp = C.AUDIO_APP;
+    this._meetings = {};
+    this._trackMeetingEvents();
+    this.messageFactory(this._onMessage.bind(this));
+  }
+
+  static getMetadataFromMessage (message = {}) {
+    return {
+      sfuMessageId: message.id,
+      connectionId: message.connectionId,
+      internalMeetingId: message.internalMeetingId,
+      roomId: message.voiceBridge,
+      userId: message.userId,
+    };
+  }
+
+  _trackMeetingEvents () {
+    this._bbbGW.on(C.DISCONNECT_ALL_USERS_2x, (payload) => {
+      const meetingId = payload[C.MEETING_ID_2x];
+      this._disconnectAllUsers(meetingId);
+    });
+    this._bbbGW.on(C.USER_JOINED_VOICE_CONF_MESSAGE_2x, this._handleUserJoinedVoiceConf.bind(this));
+    if (EJECT_ON_USER_LEFT) {
+      this._bbbGW.on(C.USER_LEFT_MEETING_2x, (payload) => {
+        let meetingId = payload[C.MEETING_ID_2x];
+        let userId = payload[C.USER_ID_2x];
+        this._disconnectUser(meetingId, userId);
+      });
+    }
+  }
+
+  async _handleUserJoinedVoiceConf (payload) {
+    const { userId, callerName, voiceConf, listenOnly } = payload;
+    try {
+      if (FS_HANDLE_EXTERNAL_CONNECTIONS && !listenOnly && userId.startsWith("w_")) {
+        await this.mcs.join(voiceConf, 'SFU', { userId, externalUserId: userId, name: callerName, autoLeave: true });
+      }
+    } catch (error) {
+      Logger.warn(this._logPrefix, `Failed to pre-start audio user`,
+        { userId, voiceConf, errorMessage: error.message, errorCode: error.code });
+    }
+  }
+
+  // FIXME enqueue stop
+  _disconnectAllUsers(meetingId) {
+    const sessionId = this._meetings[meetingId];
+    if (typeof sessionId !== 'undefined') {
+      const session = this._fetchSession(sessionId);
+      if (session) {
+        Logger.info(this._logPrefix, 'Disconnecting all listen only sessions',
+          { roomId: sessionId, internalMeetingId: meetingId });
+        this._stopSession(sessionId);
+      }
+      delete this._meetings[meetingId];
+    }
+  }
+
+  _disconnectUser(meetingId, userId) {
+    const sessionId = this._meetings[meetingId];
+    const session = this._fetchSession(sessionId);
+    if (session) {
+      const connectionId = session.getConnectionId(userId);
+      if (connectionId) {
+        Logger.info(this._logPrefix, 'Disconnect listen only session on UserLeft*', {
+          meetingId,
+          userId,
+          sessionId,
+          connectionId,
+        });
+        return this._closeListener(sessionId, connectionId, {
+          userId, meetingId, roomId: sessionId, connectionId,
+        }).finally(() => {
+          this._bbbGW.publish(JSON.stringify({
+            connectionId,
+            type: C.AUDIO_APP,
+            id : 'close',
+          }), C.FROM_AUDIO);
+        });
+      }
+    }
+  }
+
+  _handleSessionWideError (error, sessionId, rawMessage) {
+    Logger.error(this._logPrefix, `Listen only session wide fatal failure`, {
+        errorMessage: error.message,
+        errorCode: error.code,
+        ...AudioManager.getMetadataFromMessage(rawMessage),
+    });
+
+    error.id = 'webRTCAudioError';
+    this._stopSession(sessionId);
+    this.sendToClient({
+      type: 'audio',
+      ...error,
+    }, C.FROM_AUDIO);
+  }
+
+  _handleListenerStartError (session, userConnectionId, error, rawMessage) {
+    Logger.error(this._logPrefix, `Listen only listener failure`, {
+      errorMessage: error.message,
+      errorCode: error.code,
+      ...AudioManager.getMetadataFromMessage(rawMessage),
+    });
+
+    error.id = 'webRTCAudioError';
+    if (session) session.stopListener(userConnectionId);
+    this.sendToClient(({
+      type: 'audio',
+      ...error,
+    }), C.FROM_AUDIO);
+  }
+
+  async handleStart (message) {
+    const {
+      connectionId,
+      voiceBridge: sessionId,
+      internalMeetingId,
+      sdpOffer,
+      userId,
+      userName,
+      mediaServer = AUDIO_MEDIA_SERVER,
+    } = message;
+
+    let session = this._fetchSession(sessionId);
+    const iceQueue = this._fetchIceQueue(this._getReqIdentifier(sessionId, connectionId));
+
+    if (session == null) {
+      session = new Audio(this._bbbGW, sessionId, this.mcs, internalMeetingId, mediaServer);
+      this._sessions[sessionId] = {}
+      this._sessions[sessionId] = session;
+    }
+
+    this._meetings[internalMeetingId] = sessionId;
+
+    // starts audio session by sending sessionID, websocket and sdpoffer
+    return session.start(sessionId, connectionId, sdpOffer, userId, userName)
+      .then(sdpAnswer => {
+        // Empty ice queue after starting audio
+        this._flushIceQueue(session, iceQueue);
+
+        session.once(C.MEDIA_SERVER_OFFLINE, async (event) => {
+          const errorMessage = this._handleError(this._logPrefix, connectionId, session.globalAudioBridge, C.RECV_ROLE, errors.MEDIA_SERVER_OFFLINE);
+          return this._handleSessionWideError(errorMessage, sessionId, message);
+        });
+
+        this.sendToClient({
+          type: 'audio',
+          connectionId,
+          id : 'startResponse',
+          response : 'accepted',
+          sdpAnswer : sdpAnswer
+        }, C.FROM_AUDIO);
+
+        Logger.info(this._logPrefix, `Started listen only session for user ${userId}`,
+          AudioManager.getMetadataFromMessage(message));
+      })
+      .catch(error => {
+        const normalizedError = this._handleError(this._logPrefix, connectionId, null, C.RECV_ROLE, error);
+        // Global audio bridge startup error; notify the listener and roll back session creation
+        if (error.code=== ERRORS.SFU_GLOBAL_AUDIO_FAILED.code) {
+          this._handleSessionWideError(normalizedError, sessionId, message);
+        } else {
+          // Listener-bound errors; rollback is done internally, just notify the user
+          this._handleListenerStartError(session, connectionId, normalizedError, message);
+        }
+      });
+  }
+
+  _getReqIdentifier (sessionId, connectionId) {
+    return `${sessionId}:${connectionId}`;
+  }
+
+  _closeListener (sessionId, connectionId, metadata = {}) {
+    const session = this._fetchSession(sessionId);
+
+    if (session) {
+      return session.stopListener(connectionId)
+        .then(() => {
+          this._deleteIceQueue(this._getReqIdentifier(sessionId, connectionId));
+          Logger.info(this._logPrefix, 'Listen only listener destroyed',
+            metadata);
+        })
+        .catch((error) => {
+          this._deleteIceQueue(this._getReqIdentifier(sessionId, connectionId));
+          Logger.error(this._logPrefix, 'Listen only listener stop failed', {
+              errorMessage: error.message,
+              errorCode: error.code,
+              ...metadata,
+            });
+        });
+    }
+
+    return Promise.resolve();
+  }
+
+  handleStop (message) {
+    const {
+      voiceBridge: sessionId,
+      connectionId,
+    } = message;
+    const logMetadata = AudioManager.getMetadataFromMessage(message);
+
+    return this._closeListener(sessionId, connectionId, logMetadata);
+  }
+
+  handleClose (message) {
+    const {
+      voiceBridge: sessionId,
+      connectionId,
+    } = message;
+    const logMetadata = AudioManager.getMetadataFromMessage(message);
+
+    Logger.info(this._logPrefix, 'Connection closed', logMetadata)
+
+    return this._closeListener(sessionId, connectionId, logMetadata);
+  }
+
+  handleSubscriberAnswer (message) {
+    const {
+      voiceBridge: sessionId,
+      connectionId,
+      sdpOffer: answer,
+    } = message;
+
+    const session = this._fetchSession(sessionId);
+
+    if (session) {
+      const metadata = AudioManager.getMetadataFromMessage(message);
+      session.processAnswer(answer, connectionId).then(() => {
+        Logger.debug(this._logPrefix, 'Listen only remote description processed',
+          metadata
+        );
+      }).catch(error => {
+        Logger.error(this._logPrefix,  'Remote description processing failed', {
+          errorMessage: error.message,
+          errorCode: error.code,
+          metadata,
+        });
+      });
+    }
+  }
+
+
+  handleIceCandidate (message) {
+    const {
+      voiceBridge: sessionId,
+      connectionId,
+      candidate,
+    } = message;
+
+    const session = this._fetchSession(sessionId);
+    const iceQueue = this._fetchIceQueue(this._getReqIdentifier(sessionId, connectionId));
+
+    if (session) {
+      session.onIceCandidate(candidate, connectionId);
+    } else {
+      iceQueue.push(candidate);
+    }
+  }
+
+
+  async _onMessage(message) {
+    Logger.trace(this._logPrefix, `Received message from ${message.connectionId}: ${message.id}`);
+
+    let queue;
+
+    switch (message.id) {
+      case 'start':
+        queue = this._fetchLifecycleQueue(this._getReqIdentifier(message.voiceBridge, message.connectionId));
+        queue.push(() => { return this.handleStart(message) });
+        break;
+
+      case 'stop':
+        queue = this._fetchLifecycleQueue(this._getReqIdentifier(message.voiceBridge, message.connectionId));
+        queue.push(() => { return this.handleStop(message) });
+        break;
+
+      case 'subscriberAnswer':
+        this.handleSubscriberAnswer(message);
+        break;
+
+      case 'iceCandidate':
+        this.handleIceCandidate(message);
+        break;
+
+      case 'close':
+        queue = this._fetchLifecycleQueue(this._getReqIdentifier(message.voiceBridge, message.connectionId));
+        queue.push(() => { return this.handleClose(message) });
+        break;
+
+      default:
+        const { connectionId }  = message;
+        const errorMessage = this._handleError(this._logPrefix, connectionId, null, null, errors.SFU_INVALID_REQUEST);
+        this.sendToClient({
+          type: 'audio',
+          ...errorMessage,
+        }, C.FROM_AUDIO);
+        break;
+    }
+  }
+};

--- a/lib/audio/FullAudioManager.js
+++ b/lib/audio/FullAudioManager.js
@@ -1,7 +1,8 @@
 /*
  * Lucas Fialho Zawacki
  * Paulo Renato Lanzarin
- * (C) Copyright 2017 Bigbluebutton
+ * Mario Gasparoni Junior
+ * (C) Copyright 2017-2021 Bigbluebutton
  *
  */
 
@@ -16,9 +17,10 @@ const errors = require('../base/errors');
 const config = require('config');
 const ERRORS = require('../base/errors.js');
 
-const { handleExternalConnections : FS_HANDLE_EXTERNAL_CONNECTIONS } = config.get('freeswitch');
+const { handleExternalConnections : FS_HANDLE_EXTERNAL_CONNECTIONS }
+  = config.get('freeswitch');
 const EJECT_ON_USER_LEFT = config.get('ejectOnUserLeft');
-const AUDIO_MEDIA_SERVER = config.get('audioMediaServer');
+const AUDIO_MEDIA_SERVER = config.get('fullAudioMediaServer');
 
 module.exports = class AudioManager extends BaseManager {
   constructor (connectionChannel, additionalChannels, logPrefix) {
@@ -144,6 +146,8 @@ module.exports = class AudioManager extends BaseManager {
       userId,
       userName,
       mediaServer = AUDIO_MEDIA_SERVER,
+      role,
+      caleeName,
     } = message;
 
     let session = this._fetchSession(sessionId);
@@ -158,7 +162,8 @@ module.exports = class AudioManager extends BaseManager {
     this._meetings[internalMeetingId] = sessionId;
 
     // starts audio session by sending sessionID, websocket and sdpoffer
-    return session.start(sessionId, connectionId, sdpOffer, userId, userName)
+    return session.start(sessionId, connectionId, sdpOffer, userId, userName,
+      role, caleeName)
       .then(sdpAnswer => {
         // Empty ice queue after starting audio
         this._flushIceQueue(session, iceQueue);

--- a/lib/audio/FullAudioProcess.js
+++ b/lib/audio/FullAudioProcess.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const AudioManager= require('./AudioManager');
+const BaseProcess = require('../base/BaseProcess');
+const C = require('../bbb/messages/Constants');
+
+const manager = new AudioManager(C.TO_AUDIO, [C.FROM_AKKA_APPS], C.AUDIO_MANAGER_PREFIX);
+const newProcess = new BaseProcess(manager, C.AUDIO_PROCESS_PREFIX);
+
+newProcess.start();

--- a/lib/audio/FullAudioProcess.js
+++ b/lib/audio/FullAudioProcess.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AudioManager= require('./AudioManager');
+const AudioManager= require('./FullAudioManager');
 const BaseProcess = require('../base/BaseProcess');
 const C = require('../bbb/messages/Constants');
 

--- a/lib/audio/fullaudio.js
+++ b/lib/audio/fullaudio.js
@@ -1,0 +1,822 @@
+'use strict';
+
+const config = require('config');
+const C = require('../bbb/messages/Constants');
+const Logger = require('../utils/Logger');
+const Messaging = require('../bbb/messages/Messaging');
+const BaseProvider = require('../base/BaseProvider');
+const errors = require('../base/errors.js');
+
+const LOG_PREFIX = "[audio]";
+const GLOBAL_AUDIO_PREFIX = "GLOBAL_AUDIO_";
+
+const GLOBAL_AUDIO_CONNECTION_TIMEOUT = config.get('mediaFlowTimeoutDuration');
+const MEDIA_FLOW_TIMEOUT_DURATION = config.get('mediaFlowTimeoutDuration');
+const MEDIA_STATE_TIMEOUT_DURATION = config.get('mediaStateTimeoutDuration');
+const PERMISSION_PROBES = config.get('permissionProbes');
+const BRIDGE_MODE = config.has('listenOnlyGlobalAudioMode')
+  ? config.get('listenOnlyGlobalAudioMode')
+  : 'RTP';
+
+const EventEmitter = require('events');
+
+module.exports = class Audio extends BaseProvider {
+  constructor(bbbGW, voiceBridge, mcs, meetingId, mediaServer) {
+    super(bbbGW);
+    this.sfuApp = C.AUDIO_APP;
+    this.mcs = mcs;
+    this.voiceBridge = voiceBridge;
+    this.globalAudioBridge = `${GLOBAL_AUDIO_PREFIX}${this.voiceBridge}`;
+    this.sourceAudio;
+    this.sourceAudioStarted = false;
+    this.sourceAudioStatus = C.MEDIA_STOPPED;
+    this.audioEndpoints = {};
+    this.userId;
+    this._mediaFlowingTimeouts = {};
+    this._mediaStateTimeouts = {};
+    this.connectedUsers = {};
+    this.candidatesQueue = {}
+    this.meetingId = meetingId;
+    this.handleMCSCoreDisconnection = this.handleMCSCoreDisconnection.bind(this);
+    this.mcs.on(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
+    this.mediaServer = mediaServer;
+  }
+
+  set sourceAudioStatus (status) {
+    this._sourceAudioStatus = status;
+    this.emit(this._sourceAudioStatus);
+  }
+
+  get sourceAudioStatus () {
+    return this._sourceAudioStatus;
+  }
+
+  _getPartialLogMetadata () {
+    return {
+      roomId: this.voiceBridge,
+      internalMeetingId: this.meetingId,
+      status: this.sourceAudioStatus,
+    };
+  }
+
+  _getFullLogMetadata (connectionId) {
+    const { userId } = this.getUser(connectionId, true) || {};
+    const { mcsUserId, mediaId } = this.audioEndpoints[connectionId] || {};
+    return {
+      roomId: this.voiceBridge,
+      internalMeetingId: this.meetingId,
+      mcsUserId,
+      userId,
+      mediaId,
+      status: this.sourceAudioStatus,
+      connectionId,
+    };
+  }
+
+  /* ======= ICE HANDLERS ======= */
+
+  onIceCandidate (_candidate, connectionId) {
+    const endpoint = this.audioEndpoints[connectionId];
+
+    if (endpoint && endpoint.mediaId) {
+      try {
+        this._flushCandidatesQueue(connectionId);
+        this.mcs.addIceCandidate(endpoint.mediaId, _candidate);
+      }
+      catch (error)   {
+        Logger.error(LOG_PREFIX, "ICE candidate could not be added to media controller.",
+          { ...this._getFullLogMetadata(connectionId), error });
+      }
+    } else {
+      if(!this.candidatesQueue[connectionId]) {
+        this.candidatesQueue[connectionId] = [];
+      }
+      this.candidatesQueue[connectionId].push(_candidate);
+    }
+  };
+
+  async _flushCandidatesQueue (connectionId) {
+    const endpoint = this.audioEndpoints[connectionId];
+
+    if (endpoint && endpoint.mediaId) {
+      try {
+        if (this.candidatesQueue[connectionId]) {
+          this.flushCandidatesQueue(this.mcs, [...this.candidatesQueue[connectionId]], endpoint.mediaId);
+          this.candidatesQueue[connectionId] = [];
+        }
+      }
+      catch (error) {
+        Logger.error(LOG_PREFIX, "ICE candidate could not be added to media controller.",
+          { ...this._getFullLogMetadata(connectionId), error });
+      }
+    }
+  }
+
+  /* ======= USER STATE MANAGEMENT ======= */
+
+  /**
+   * Include user to a hash object indexed by it's connectionId
+   * @param  {String} connectionId Current connection id at the media manager
+   * @param  {Object} user {userId: String, userName: String}
+   */
+  addUser (connectionId, user) {
+    if (this.connectedUsers.hasOwnProperty(connectionId)) {
+      Logger.debug(LOG_PREFIX, `Updating user for connectionId ${connectionId}`,
+        this._getFullLogMetadata(connectionId));
+    }
+    this.connectedUsers[connectionId] = user;
+    Logger.debug(LOG_PREFIX, `Added user with connectionId ${connectionId}`,
+      this._getFullLogMetadata(connectionId));
+  };
+
+  static isValidUser (user) {
+    return user && user.userId && user.userName;
+  }
+
+  /**
+   * Exclude user from a hash object indexed by it's connectionId
+   * @param  {String} connectionId Current connection id at the media manager
+   */
+  removeUser(connectionId) {
+    if (this.connectedUsers.hasOwnProperty(connectionId)) {
+      Logger.info(LOG_PREFIX, `Removing user with connectionId ${connectionId}`,
+        this._getFullLogMetadata(connectionId));
+      delete this.connectedUsers[connectionId];
+    } else {
+      Logger.debug(LOG_PREFIX, `User not found on remove for connectionId ${connectionId}`,
+        this._getPartialLogMetadata());
+    }
+  };
+
+/**
+ * Consult user from a hash object indexed by it's connectionId
+ * @param  {String} connectionId Current connection id at the media manager
+ * @return  {Object} user {userId: String, userName: String}
+ */
+  getUser (connectionId, suppressLog = false) {
+    if (this.connectedUsers.hasOwnProperty(connectionId)) {
+      return this.connectedUsers[connectionId];
+    } else {
+      if (!suppressLog) {
+        Logger.error(LOG_PREFIX, `User not found on getUser for connectionId ${connectionId}`,
+          this._getPartialLogMetadata());
+      }
+
+      return {};
+    }
+  };
+
+  /**
+  * Consult connectionId from a hash object composed by users {userId: String, userName: String}
+  * @param  {String} userId user id of a specific user at the media manager
+  * @return  {String} connectionId
+  */
+   getConnectionId(userId) {
+     for (var key in this.connectedUsers) {
+       if (this.connectedUsers.hasOwnProperty(key)) {
+         let user = this.connectedUsers[key]
+         if (user.hasOwnProperty('userId') && user['userId'] === userId) {
+           return key;
+         }
+       }
+     }
+     Logger.error(LOG_PREFIX, `User not found on getConnectionId for userId ${userId}`,
+      this._getPartialLogMetadata());
+   };
+
+  getGlobalAudioPermission (meetingId, voiceBridge, userId, sfuSessionId) {
+    if (!PERMISSION_PROBES) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const onResp = (payload) => {
+        const { meetingId, voiceBridge, userId, allowed } = payload;
+        if (meetingId === payload.meetingId
+          && payload.voiceBridge === voiceBridge
+          && payload.userId === userId
+          && payload.allowed) {
+          return resolve();
+        }
+
+        return reject(errors.SFU_UNAUTHORIZED);
+      }
+
+      const msg = Messaging.generateGetGlobalAudioPermissionReqMsg(meetingId, voiceBridge, userId, sfuSessionId);
+      this.bbbGW.once(C.GET_GLOBAL_AUDIO_PERM_RESP_MSG+sfuSessionId, onResp);
+      this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
+    });
+  }
+
+  /* ======= MEDIA TIMEOUT HANDLERS ===== */
+
+  _onSubscriberMediaFlowing (connectionId) {
+    Logger.debug(LOG_PREFIX, `Listen only WebRTC media is FLOWING`,
+      this._getFullLogMetadata(connectionId));
+    this.clearMediaFlowingTimeout(connectionId);
+    this.sendUserConnectedToGlobalAudioMessage(connectionId);
+    this.sendToClient({
+      type: 'audio',
+      connectionId: connectionId,
+      id: "webRTCAudioSuccess",
+      success: "MEDIA_FLOWING"
+    }, C.FROM_AUDIO);
+  };
+
+  _onSubscriberMediaNotFlowing (connectionId) {
+    Logger.debug(LOG_PREFIX, `Listen only WebRTC media is NOT_FLOWING`,
+      this._getFullLogMetadata(connectionId));
+    this.setMediaFlowingTimeout(connectionId);
+  }
+
+  _onSubscriberMediaNotFlowingTimeout (connectionId) {
+    Logger.error(LOG_PREFIX, `Listen only WebRTC media NOT_FLOWING timeout reached`,
+      this._getFullLogMetadata(connectionId));
+    this.sendToClient({
+      type: 'audio',
+      connectionId: connectionId,
+      id: "webRTCAudioError",
+      error: { code: 2211 , reason: errors[2211] },
+    }, C.FROM_AUDIO);
+  };
+
+  setMediaFlowingTimeout (connectionId) {
+    if (!this._mediaFlowingTimeouts[connectionId]) {
+      Logger.debug(LOG_PREFIX, `Listen only NOT_FLOWING timeout set`,
+        { ...this._getFullLogMetadata(connectionId), MEDIA_FLOW_TIMEOUT_DURATION });
+      this._mediaFlowingTimeouts[connectionId] = setTimeout(() => {
+        this._onSubscriberMediaNotFlowingTimeout(connectionId);
+      }, MEDIA_FLOW_TIMEOUT_DURATION);
+    }
+  }
+
+  clearMediaFlowingTimeout (connectionId) {
+    if (this._mediaFlowingTimeouts[connectionId]) {
+      Logger.debug(LOG_PREFIX, `clearMediaFlowingTimeout for listener ${connectionId}`,
+        this._getFullLogMetadata(connectionId));
+      clearTimeout(this._mediaFlowingTimeouts[connectionId]);
+      delete this._mediaFlowingTimeouts[connectionId]
+    }
+  }
+
+  _onSubscriberMediaConnected (connectionId) {
+    Logger.info(LOG_PREFIX, `Listen only WebRTC media is CONNECTED`,
+      this._getFullLogMetadata(connectionId));
+    this.clearMediaStateTimeout(connectionId);
+  };
+
+  _onSubscriberMediaDisconnected (connectionId) {
+    Logger.warn(LOG_PREFIX, `Listen only WebRTC media is DISCONNECTED`,
+      this._getFullLogMetadata(connectionId));
+    this.setMediaStateTimeout(connectionId);
+  }
+
+  _onSubscriberMediaDisconnectedTimeout (connectionId) {
+    Logger.error(LOG_PREFIX, `Listen only WebRTC media DISCONNECTED timeout reached`,
+      this._getFullLogMetadata(connectionId));
+
+    this.sendToClient({
+      type: 'audio',
+      connectionId: connectionId,
+      id: "webRTCAudioError",
+      error: { code: 2211 , reason: errors[2211] },
+    }, C.FROM_AUDIO);
+  };
+
+  setMediaStateTimeout (connectionId) {
+    if (!this._mediaStateTimeouts[connectionId]) {
+      Logger.warn(LOG_PREFIX, `Listen only DISCONNECTED media state timeout set`,
+        { ...this._getFullLogMetadata(connectionId), MEDIA_STATE_TIMEOUT_DURATION });
+      this._mediaStateTimeouts[connectionId] = setTimeout(() => {
+        this._onSubscriberMediaDisconnectedTimeout(connectionId);
+      }, MEDIA_STATE_TIMEOUT_DURATION);
+    }
+  }
+
+  clearMediaStateTimeout (connectionId) {
+    if (this._mediaStateTimeouts[connectionId]) {
+      Logger.debug(LOG_PREFIX, `clearMediaStateTimeout for listener ${connectionId}`,
+        this._getFullLogMetadata(connectionId));
+      clearTimeout(this._mediaStateTimeouts[connectionId]);
+      delete this._mediaStateTimeouts[connectionId]
+    }
+  }
+
+  /* ======= MEDIA STATE HANDLERS ======= */
+
+  _onBridgeMediaStateChange (event, endpoint) {
+    const { mediaId, state } = event;
+    const { name, details = null } = state;
+
+    if (mediaId !== endpoint) {
+      return;
+    }
+
+    switch (name) {
+      case "MediaStateChanged":
+        break;
+
+      case "MediaFlowOutStateChange":
+        Logger.info(LOG_PREFIX, `RTP source relay session ${mediaId} received MediaFlowOut`,
+          { ...this._getPartialLogMetadata(), userId: this.userId, mediaId, state });
+        break;
+
+      case "MediaFlowInStateChange":
+        Logger.info(LOG_PREFIX, `RTP source relay session ${mediaId} received MediaFlowIn`,
+          { ...this._getPartialLogMetadata(), userId: this.userId, mediaId, state });
+        break;
+
+      default: Logger.warn(LOG_PREFIX, "Unrecognized event", event);
+    }
+  }
+
+  _onMCSIceCandidate (event, endpoint, connectionId) {
+    const { mediaId, candidate } = event;
+
+    if (mediaId !== endpoint) {
+      return;
+    }
+
+    Logger.debug(LOG_PREFIX, `Received ICE candidate from mcs-core`,
+      { ...this._getFullLogMetadata(connectionId), candidate });
+
+    this.sendToClient({
+      type: 'audio',
+      connectionId,
+      id : 'iceCandidate',
+      candidate : candidate
+    }, C.FROM_AUDIO);
+  }
+
+  _handleIceComponentStateChange (state, logMetadata) {
+    const { rawEvent } = state;
+    const {
+      componentId: iceComponentId,
+      source: elementId,
+      state: iceComponentState
+    } = rawEvent;
+
+    Logger.debug(LOG_PREFIX, `Audio ICE component state changed`, {
+      ...logMetadata,
+      elementId,
+      iceComponentId,
+      iceComponentState
+    });
+  }
+
+  _handleCandidatePairSelected (state, logMetadata) {
+    const { rawEvent } = state;
+    const { candidatePair, source: elementId } = rawEvent;
+    const { localCandidate, remoteCandidate, componentID: iceComponentId } = candidatePair;
+    Logger.info(LOG_PREFIX, `Audio new candidate pair selected`, {
+      ...logMetadata,
+      elementId,
+      iceComponentId,
+      localCandidate,
+      remoteCandidate,
+    });
+  }
+
+  _handleIceGatheringDone (state, logMetadata) {
+    const { rawEvent } = state;
+    const { source: elementId } = rawEvent;
+    Logger.debug(LOG_PREFIX, "Audio ICE gathering done", {
+      ...logMetadata,
+      elementId,
+    });
+  }
+
+  _handleMediaStateChanged (state, connectionId, logMetadata) {
+    const { rawEvent, details } = state;
+    const { source: elementId } = rawEvent;
+    Logger.debug(LOG_PREFIX, "Audio media state changed", {
+      ...logMetadata,
+      elementId,
+      mediaState: details,
+    });
+
+    if (details === 'CONNECTED') {
+      this._onSubscriberMediaConnected(connectionId);
+    } else if (details === 'DISCONNECTED') {
+      this._onSubscriberMediaDisconnected(connectionId);
+    }
+  }
+
+  _mediaStateWebRTC (event, endpoint, connectionId) {
+    const { mediaId , state } = event;
+    const { name, details } = state;
+    const logMetadata = this._getFullLogMetadata(connectionId);
+
+    if (mediaId !== endpoint) {
+      return;
+    }
+
+    switch (name) {
+      case "IceComponentStateChange":
+        this._handleIceComponentStateChange(state, logMetadata);
+        break;
+      case "NewCandidatePairSelected":
+        this._handleCandidatePairSelected(state, logMetadata);
+        break;
+      case "IceGatheringDone":
+        this._handleIceGatheringDone(state, logMetadata);
+        break;
+      case "MediaStateChanged":
+        this._handleMediaStateChanged(state, connectionId, logMetadata);
+        break;
+
+      case "MediaFlowOutStateChange":
+      case "MediaFlowInStateChange":
+        Logger.debug(LOG_PREFIX, `Listen only WebRTC media received MediaFlow state`,
+          { ...logMetadata, state });
+
+        if (details === 'FLOWING') {
+          this._onSubscriberMediaFlowing(connectionId);
+        } else {
+          this._onSubscriberMediaNotFlowing(connectionId);
+        }
+        break;
+
+      case C.MEDIA_SERVER_OFFLINE:
+        Logger.error(LOG_PREFIX, `WebRTC listen only session ${mediaId} received MEDIA_SERVER_OFFLINE event`,
+          { ...logMetadata, event });
+
+        this.emit(C.MEDIA_SERVER_OFFLINE, event);
+        break;
+
+      default: Logger.warn(LOG_PREFIX, `Unrecognized event`, { event });
+    }
+  }
+
+  /* ======= START/CONNECTION METHODS ======= */
+
+  _waitForGlobalAudio () {
+    const waitForConnection = () => {
+      return new Promise((resolve, reject) => {
+        const onMediaStarted = () =>  {
+          this.removeListener(C.MEDIA_NEGOTIATION_FAILED, onMediaFailed);
+          this.removeListener(C.MEDIA_STOPPED, onMediaFailed);
+          resolve(true)
+        };
+        const onMediaFailed = () =>  {
+          this.removeListener(C.MEDIA_NEGOTIATION_FAILED, onMediaFailed);
+          this.removeListener(C.MEDIA_STOPPED, onMediaFailed);
+          this.removeListener(C.MEDIA_STARTED, onMediaStarted);
+          reject(false)
+        };
+
+        this.once(C.MEDIA_STARTED, onMediaStarted);
+        this.once(C.MEDIA_NEGOTIATION_FAILED, onMediaFailed);
+        this.once(C.MEDIA_STOPPED, onMediaFailed);
+      });
+    };
+
+    const connectionProbe = () => {
+        switch (this.sourceAudioStatus) {
+          case C.MEDIA_STARTED:
+            return Promise.resolve(true);
+            break;
+          case C.MEDIA_STOPPED:
+            return this.startGlobalAudioBridge();
+            break;
+          default:
+            return waitForConnection();
+        }
+    };
+
+    const failOver = () => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          return reject(errors.MEDIA_SERVER_REQUEST_TIMEOUT);
+        }, GLOBAL_AUDIO_CONNECTION_TIMEOUT);
+      });
+    };
+
+    return Promise.race([connectionProbe(), failOver()]);
+  }
+
+  _startGABridge (transportType) {
+      return new Promise(async (resolve, reject) => {
+      Logger.info(LOG_PREFIX,  `Starting WebRTC source audio/GLOBAL_AUDIO for ${this.voiceBridge}`,
+        this._getPartialLogMetadata());
+      try {
+        if (!this.sourceAudioStarted && this.sourceAudioStatus === C.MEDIA_STOPPED) {
+          this.sourceAudioStatus = C.MEDIA_STARTING;
+
+          const isConnected = await this.mcs.waitForConnection();
+
+          if (!isConnected) {
+            return reject(errors.MEDIA_SERVER_OFFLINE);
+          }
+
+          const userId = await this.mcs.join(
+            this.voiceBridge,
+            'SFU',
+            { name: this.globalAudioBridge },
+          );
+          this.userId = userId;
+
+          // Subscribe to the GLOBAL_AUDIO endpoint created above. This will
+          // act as the WRTC relay which will generate the answer descripto for
+          // the endpoint published above
+          const proxyOptions = {
+            adapter: this.mediaServer,
+            name: `PROXY_${this.globalAudioBridge}|subscribe`,
+            ignoreThresholds: true,
+            hackForceActiveDirection: true,
+            trickle: false,
+            profiles: {
+              audio: 'recvonly',
+            },
+            mediaProfile: 'audio',
+            adapterOptions: {
+              msHackRTPAVPtoRTPAVPF: true,
+            },
+          }
+
+          const { mediaId: proxyId, answer: proxyOffer } = await this.mcs.publish(
+            this.userId,
+            this.voiceBridge,
+            transportType,
+            proxyOptions,
+          );
+
+          this.mcs.onEvent(C.MEDIA_STATE, proxyId, (event) => {
+            this._onBridgeMediaStateChange(event, proxyId);
+          });
+
+          const globalAudioOptions = {
+            adapter: 'Freeswitch',
+            name: this.globalAudioBridge,
+            ignoreThresholds: true,
+            descriptor: proxyOffer,
+            profiles: {
+              audio: 'sendonly',
+            },
+            mediaProfile: 'audio',
+          }
+
+          // Publish with server acting as offerer. Answer is here is actually the
+          // offeree descriptor which will be processed by a relay WRTC endpoint
+          const { mediaId, answer: globalAudioAnswer } = await this.mcs.publish(
+            this.userId,
+            this.voiceBridge,
+            transportType,
+            globalAudioOptions
+          );
+
+          // Renegotiate the source endpoint passing the answer generated by the
+          // relay WRTC ep
+          await this.mcs.publish(
+            this.userId,
+            this.voiceBridge,
+            transportType,
+            { ...proxyOptions, mediaId: proxyId, descriptor: globalAudioAnswer }
+          );
+
+          this.sourceAudio = proxyId;
+          this.sourceAudioStarted = true;
+          this.sourceAudioStatus = C.MEDIA_STARTED;
+          this.emit(C.MEDIA_STARTED);
+
+          Logger.info(LOG_PREFIX, `Listen only source WebRTC relay successfully created`,
+            { ...this._getPartialLogMetadata(), mediaId: this.sourceAudio, userId: this.userId });
+          return resolve(true);
+        }
+      } catch (error) {
+        Logger.error(LOG_PREFIX, `Error on starting listen only source WebRTC relay`,
+          { ...this._getPartialLogMetadata(), error });
+        this.sourceAudioStatus = C.MEDIA_NEGOTIATION_FAILED;
+        this._stopSourceAudio();
+        return reject(error);
+      }
+    });
+  }
+
+  startGlobalAudioBridge () {
+    switch (BRIDGE_MODE) {
+      case 'WebRTC':
+        return this._startGABridge(C.WEBRTC);
+      case 'RTP':
+      default:
+        return this._startGABridge(C.RTP);
+    }
+  }
+
+  async start (sessionId, connectionId, sdpOffer, userId, userName) {
+    let mcsUserId;
+    const isConnected = await this.mcs.waitForConnection();
+
+    if (!isConnected) {
+      throw this._handleError(LOG_PREFIX, errors.MEDIA_SERVER_OFFLINE, "recv", userId);
+    }
+
+    try {
+      await this.getGlobalAudioPermission(this.meetingId, this.voiceBridge, userId, connectionId);
+    } catch (error) {
+      const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
+      Logger.error(LOG_PREFIX, 'New listen only session failed: unauthorized',
+        { ...this._getPartialLogMetadata(), error: normalizedError });
+      throw normalizedError;
+    }
+
+    try {
+      await this._waitForGlobalAudio();
+    } catch (error) {
+      const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
+      Logger.error(LOG_PREFIX, `New listen only session failed: GLOBAL_AUDIO unavailable`,
+        { ...this._getPartialLogMetadata(), error: normalizedError });
+      throw errors.SFU_GLOBAL_AUDIO_FAILED;
+    }
+
+    try {
+      mcsUserId = await this.mcs.join(
+        this.voiceBridge,
+        'SFU',
+        { externalUserId: userId, autoLeave: true }
+      );
+    } catch (error) {
+      const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
+      Logger.error(LOG_PREFIX, `mcs-core join failure for new listen only session`, {
+        ...this._getPartialLogMetadata(),
+        connectionId,
+        userId,
+        error: normalizedError
+      });
+      throw normalizedError;
+    }
+
+    // Storing the user data to be used by the pub calls
+    const user = { userId, userName, mcsUserId, connected: false };
+    this.addUser(connectionId, user);
+    Logger.info(LOG_PREFIX, `Starting new listen only session`,
+      this._getFullLogMetadata(connectionId));
+
+    try {
+      const sdpAnswer = await this._subscribeToGlobalAudio(sdpOffer, connectionId);
+      return sdpAnswer;
+    } catch (error) {
+      const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
+      Logger.error(LOG_PREFIX, `GLOBAL_AUDIO subscribe failed`, {
+        ...this._getPartialLogMetadata(),
+        connectionId,
+        userId,
+        error: normalizedError
+      });
+
+      // Rollback
+      this.sendUserDisconnectedFromGlobalAudioMessage(connectionId);
+      throw normalizedError;
+    }
+  }
+
+  async _subscribeToGlobalAudio (sdpOffer, connectionId) {
+    const { userId, mcsUserId } = this.getUser(connectionId);
+    const options = {
+      descriptor: sdpOffer,
+      adapter: this.mediaServer,
+      name: this._assembleStreamName('subscribe', userId, this.meetingId),
+      ignoreThresholds: true,
+      profiles: {
+        audio: 'recvonly',
+      },
+      mediaProfile: 'audio',
+    }
+
+    let mediaId, answer;
+
+    try {
+      ({ mediaId, answer } = await this.mcs.subscribe(mcsUserId,
+        this.sourceAudio, C.WEBRTC, options));
+    } catch (subscribeError) {
+      Logger.error(LOG_PREFIX, `New listen only session failed to subscribe to GLOBAL_AUDIO`,
+        { ...this._getPartialLogMetadata(), subscribeError});
+      throw (this._handleError(LOG_PREFIX, subscribeError, "recv", connectionId));
+    }
+
+    this.mcs.onEvent(C.MEDIA_STATE, mediaId, (event) => {
+      this._mediaStateWebRTC(event, mediaId, connectionId);
+    });
+
+    this.mcs.onEvent(C.MEDIA_STATE_ICE, mediaId, (event) => {
+      this._onMCSIceCandidate(event, mediaId, connectionId);
+    });
+
+    this.audioEndpoints[connectionId] = { mcsUserId, mediaId };
+    this._flushCandidatesQueue(connectionId);
+    Logger.info(LOG_PREFIX, 'Listen only session subscribed to global audio',
+      this._getFullLogMetadata(connectionId));
+    return answer;
+  }
+
+  processAnswer (answer, connectionId) {
+    const endpoint = this.audioEndpoints[connectionId];
+
+    Logger.debug(LOG_PREFIX, 'Processing listen only answer',
+      this._getFullLogMetadata(connectionId));
+
+    if (endpoint && endpoint.mediaId) {
+      const options = {
+        mediaId: endpoint.mediaId,
+        descriptor: answer,
+        adapter: this.mediaServer,
+        name: this._assembleStreamName('subscribe', endpoint.mcsUserId, this.meetingId),
+        ignoreThresholds: true,
+        profiles: {
+          audio: 'recvonly',
+        },
+      }
+
+      return this.mcs.subscribe(endpoint.mcsUserId, this.sourceAudio, C.WEBRTC, options);
+    }
+  }
+
+  /* ======= STOP METHODS ======= */
+
+  async stopListener(connectionId) {
+    const listener = this.audioEndpoints[connectionId];
+
+    if (listener && listener.mediaId && listener.mcsUserId) {
+      try {
+        await this.mcs.unsubscribe(listener.mcsUserId, listener.mediaId);
+        Logger.info(LOG_PREFIX, 'Listen only session stopped',
+          this._getFullLogMetadata(connectionId));
+      } catch (error) {
+        Logger.warn(LOG_PREFIX, `Error on unsubscribing listener media ${listener.mediaId}`,
+          { ...this._getFullLogMetadata(connectionId), error});
+      }
+    }
+
+    this.sendUserDisconnectedFromGlobalAudioMessage(connectionId);
+
+    if (this.audioEndpoints && Object.keys(this.audioEndpoints).length === 1) {
+      this._stopSourceAudio();
+    }
+
+    delete this.candidatesQueue[connectionId];
+    delete this.audioEndpoints[connectionId];
+    this.clearMediaFlowingTimeout(connectionId);
+    this.clearMediaStateTimeout(connectionId);
+  }
+
+  async stop () {
+    Logger.info(LOG_PREFIX, `Listen only session-wide stop for room ${this.voiceBridge}, releasing everything`,
+      this._getPartialLogMetadata());
+    this.mcs.removeListener(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
+    try {
+      const nofConnectedUsers = Object.keys(this.connectedUsers).length;
+      if (nofConnectedUsers <= 0) {
+        return this._stopSourceAudio();
+      }
+
+      for (var connectionId in this.connectedUsers) {
+        try {
+          await this.stopListener(connectionId);
+        } catch (error) {
+          Logger.error(LOG_PREFIX, `Listen only session stop failed`,
+            { ...this._getFullLogMetadata(connectionId), error });
+        }
+      }
+      return Promise.resolve();
+    }
+    catch (error) {
+      Logger.error(LOG_PREFIX, `Error on session-wide stop for room ${this.voiceBridge}}`,
+        { ...this._getPartialLogMetadata(), error });
+      return Promise.reject(this._handleError(LOG_PREFIX, error, "recv", this.userId));
+    }
+  };
+
+  async _stopSourceAudio () {
+    if (this.userId) {
+      try {
+        await this.mcs.leave(this.voiceBridge, this.userId);
+        this.userId = null;
+      } catch (error) {
+        Logger.warn(LOG_PREFIX, `Error on stopping source audio ${this.voiceBridge} with MCS user ${this.userId}`, { ...this._getPartialLogMetadata(), error });
+      }
+    }
+
+    this.sourceAudioStarted = false;
+    this.sourceAudioStatus = C.MEDIA_STOPPED;
+  }
+
+  sendUserDisconnectedFromGlobalAudioMessage(connectionId) {
+    const user = this.getUser(connectionId);
+    if (user) {
+      if (user.connected) {
+        const { userId, userName } = user;
+        const msg = Messaging.generateUserDisconnectedFromGlobalAudioMessage(this.voiceBridge, userId, userName);
+        this.bbbGW.publish(msg, C.TO_AKKA_APPS);
+      }
+
+      this.removeUser(connectionId);
+    }
+  };
+
+  sendUserConnectedToGlobalAudioMessage(connectionId) {
+    const user = this.getUser(connectionId);
+    if (user) {
+      const { userId, userName } = user;
+      const msg = Messaging.generateUserConnectedToGlobalAudioMessage(this.voiceBridge, userId, userName);
+      this.bbbGW.publish(msg, C.TO_AKKA_APPS);
+      user.connected = true;
+    }
+  };
+};

--- a/lib/audio/fullaudio.js
+++ b/lib/audio/fullaudio.js
@@ -31,7 +31,8 @@ module.exports = class Audio extends BaseProvider {
     this.sourceAudioStarted = false;
     this.sourceAudioStatus = C.MEDIA_STOPPED;
     this.audioEndpoints = {};
-    this.userId;
+    this.userId = null;
+    this.mcsUserId = null;
     this._mediaFlowingTimeouts = {};
     this._mediaStateTimeouts = {};
     this.connectedUsers = {};
@@ -457,8 +458,8 @@ module.exports = class Audio extends BaseProvider {
   }
 
   /* ======= START/CONNECTION METHODS ======= */
-  _waitForFullAudio() {
-    return this.startFullAudioBridge()
+  _waitForFullAudio(connectionId) {
+    return this.startFullAudioBridge(connectionId)
   }
 
   _waitForGlobalAudio () {
@@ -539,15 +540,15 @@ module.exports = class Audio extends BaseProvider {
             },
           }
 
-          const { mediaId: proxyId, answer: proxyOffer } = await this.mcs.publish(
+          const { mediaId: proxyMediaId, answer: proxyOffer } = await this.mcs.publish(
             this.userId,
             this.voiceBridge,
             transportType,
             proxyOptions,
           );
 
-          this.mcs.onEvent(C.MEDIA_STATE, proxyId, (event) => {
-            this._onBridgeMediaStateChange(event, proxyId);
+          this.mcs.onEvent(C.MEDIA_STATE, proxyMediaId, (event) => {
+            this._onBridgeMediaStateChange(event, proxyMediaId);
           });
 
           const fullAudioOptions = {
@@ -572,10 +573,10 @@ module.exports = class Audio extends BaseProvider {
             this.userId,
             this.voiceBridge,
             transportType,
-            { ...proxyOptions, mediaId: proxyId, descriptor: fullAudioAnswer }
+            { ...proxyOptions, mediaId: proxyMediaId, descriptor: fullAudioAnswer }
           );
 
-          this.sourceAudio = proxyId;
+          this.sourceAudio = proxyMediaId;
           this.sourceAudioStarted = true;
           this.sourceAudioStatus = C.MEDIA_STARTED;
           this.emit(C.MEDIA_STARTED);
@@ -701,8 +702,8 @@ module.exports = class Audio extends BaseProvider {
     }
   }
 
-  startFullAudioBridge () {
-    return this._startFullAudioBridge(C.RTP);
+  startFullAudioBridge (connectionId) {
+    return this._startFullAudioBridge(C.RTP, connectionId);
   }
 
   async start (sessionId, connectionId, sdpOffer, userId, userName,
@@ -722,8 +723,8 @@ module.exports = class Audio extends BaseProvider {
         await this.getFullAudioPermission(this.meetingId, this.voiceBridge,
           userId, connectionId);
 
-        await this._waitForFullAudio();
-        break
+        await this._waitForFullAudio(connectionId);
+        break;
       case 'recvonly':
       default:
         try {
@@ -752,6 +753,7 @@ module.exports = class Audio extends BaseProvider {
         'SFU',
         { externalUserId: userId, autoLeave: true }
       );
+      this.mcsUserId = mcsUserId;
     } catch (error) {
       const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
       Logger.error(LOG_PREFIX, `mcs-core join failure for new listen only session`, {
@@ -895,6 +897,20 @@ module.exports = class Audio extends BaseProvider {
   }
 
   /* ======= STOP METHODS ======= */
+  async _stopProxyEndpoints (connectionId) {
+    const { userId, mcsUserId } = this;
+
+    if (userId && mcsUserId) {
+      try {
+        await Promise.all([
+          await this.mcs.leave(this.voiceBridge, this.userId),
+          await this.mcs.leave(this.voiceBridge, this.mcsUserId),
+        ]);
+      } catch (error) {
+        Logger.warn(LOG_PREFIX, `Error on stopping source audio ${this.voiceBridge} with MCS user ${this.userId}`, { ...this._getPartialLogMetadata(), error });
+      }
+    }
+  }
 
   async stopListener(connectionId) {
     const listener = this.audioEndpoints[connectionId];
@@ -910,10 +926,19 @@ module.exports = class Audio extends BaseProvider {
       }
     }
 
-    this.sendUserDisconnectedFromGlobalAudioMessage(connectionId);
-
-    if (this.audioEndpoints && Object.keys(this.audioEndpoints).length === 1) {
-      this._stopSourceAudio();
+    switch (this.role) {
+      case 'sendrecv':
+        this._stopProxyEndpoints(connectionId);
+        break;
+      case 'recvonly':
+      default:
+        this.sendUserDisconnectedFromGlobalAudioMessage(connectionId);
+        if (this.audioEndpoints
+          && Object.keys(this.audioEndpoints).length === 1) {
+          this._stopSourceAudio();
+        }
+        await this.mcs.leave(this.voiceBridge, this.userId);
+      break;
     }
 
     delete this.candidatesQueue[connectionId];
@@ -923,8 +948,10 @@ module.exports = class Audio extends BaseProvider {
   }
 
   async stop () {
-    Logger.info(LOG_PREFIX, `Listen only session-wide stop for room ${this.voiceBridge}, releasing everything`,
+    Logger.info(LOG_PREFIX, `Fullaudio session-wide stop for room `
+      + `${this.voiceBridge}, releasing everything`,
       this._getPartialLogMetadata());
+
     this.mcs.removeListener(C.MCS_DISCONNECTED, this.handleMCSCoreDisconnection);
     try {
       const nofConnectedUsers = Object.keys(this.connectedUsers).length;

--- a/lib/audio/fullaudio.js
+++ b/lib/audio/fullaudio.js
@@ -529,7 +529,6 @@ module.exports = class Audio extends BaseProvider {
             adapter: this.mediaServer,
             name: `PROXY_${this.caleeName}|subscribe`,
             ignoreThresholds: true,
-            hackForceActiveDirection: true,
             trickle: false,
             profiles: {
               audio: 'sendrecv',

--- a/lib/audio/fullaudio.js
+++ b/lib/audio/fullaudio.js
@@ -205,13 +205,23 @@ module.exports = class Audio extends BaseProvider {
     });
   }
 
+ getFullAudioPermission(meetingId, voiceBridge, userId, sfuSessionId) {
+    return Promise.resolve(true);
+  }
+
   /* ======= MEDIA TIMEOUT HANDLERS ===== */
 
-  _onSubscriberMediaFlowing (connectionId) {
+  _onSubscriberMediaFlowing (connectionId, mediaData = {}) {
+    const { role } = mediaData;
+
     Logger.debug(LOG_PREFIX, `Listen only WebRTC media is FLOWING`,
       this._getFullLogMetadata(connectionId));
     this.clearMediaFlowingTimeout(connectionId);
-    this.sendUserConnectedToGlobalAudioMessage(connectionId);
+
+    if (!role || (role !== 'sendrecv')) {
+      this.sendUserConnectedToGlobalAudioMessage(connectionId);
+    }
+
     this.sendToClient({
       type: 'audio',
       connectionId: connectionId,
@@ -399,9 +409,10 @@ module.exports = class Audio extends BaseProvider {
     }
   }
 
-  _mediaStateWebRTC (event, endpoint, connectionId) {
+  _mediaStateWebRTC (event, endpoint, connectionId, mediaData) {
     const { mediaId , state } = event;
     const { name, details } = state;
+
     const logMetadata = this._getFullLogMetadata(connectionId);
 
     if (mediaId !== endpoint) {
@@ -428,7 +439,7 @@ module.exports = class Audio extends BaseProvider {
           { ...logMetadata, state });
 
         if (details === 'FLOWING') {
-          this._onSubscriberMediaFlowing(connectionId);
+          this._onSubscriberMediaFlowing(connectionId, mediaData);
         } else {
           this._onSubscriberMediaNotFlowing(connectionId);
         }
@@ -446,6 +457,9 @@ module.exports = class Audio extends BaseProvider {
   }
 
   /* ======= START/CONNECTION METHODS ======= */
+  _waitForFullAudio() {
+    return this.startFullAudioBridge()
+  }
 
   _waitForGlobalAudio () {
     const waitForConnection = () => {
@@ -490,6 +504,93 @@ module.exports = class Audio extends BaseProvider {
     };
 
     return Promise.race([connectionProbe(), failOver()]);
+  }
+
+  _startFullAudioBridge(transportType) {
+    return new Promise(async (resolve, reject) => {
+      Logger.info(LOG_PREFIX,  `Starting WebRTC Audio for ${this.voiceBridge}`,
+        this._getPartialLogMetadata());
+      try {
+          const isConnected = await this.mcs.waitForConnection();
+
+          if (!isConnected) {
+            return reject(errors.MEDIA_SERVER_OFFLINE);
+          }
+
+          const userId = await this.mcs.join(
+            this.voiceBridge,
+            'SFU',
+            { name: this.caleeName },
+          );
+          this.userId = userId;
+
+          const proxyOptions = {
+            adapter: this.mediaServer,
+            name: `PROXY_${this.caleeName}|subscribe`,
+            ignoreThresholds: true,
+            hackForceActiveDirection: true,
+            trickle: false,
+            profiles: {
+              audio: 'sendrecv',
+            },
+            mediaProfile: 'audio',
+            adapterOptions: {
+              msHackRTPAVPtoRTPAVPF: true,
+            },
+          }
+
+          const { mediaId: proxyId, answer: proxyOffer } = await this.mcs.publish(
+            this.userId,
+            this.voiceBridge,
+            transportType,
+            proxyOptions,
+          );
+
+          this.mcs.onEvent(C.MEDIA_STATE, proxyId, (event) => {
+            this._onBridgeMediaStateChange(event, proxyId);
+          });
+
+          const fullAudioOptions = {
+            adapter: 'Freeswitch',
+            name: this.caleeName,
+            ignoreThresholds: true,
+            descriptor: proxyOffer,
+            profiles: {
+              audio: 'sendrecv',
+            },
+            mediaProfile: 'audio',
+          }
+
+          const { answer: fullAudioAnswer } = await this.mcs.publish(
+            this.userId,
+            this.voiceBridge,
+            transportType,
+            fullAudioOptions
+          );
+
+          await this.mcs.publish(
+            this.userId,
+            this.voiceBridge,
+            transportType,
+            { ...proxyOptions, mediaId: proxyId, descriptor: fullAudioAnswer }
+          );
+
+          this.sourceAudio = proxyId;
+          this.sourceAudioStarted = true;
+          this.sourceAudioStatus = C.MEDIA_STARTED;
+          this.emit(C.MEDIA_STARTED);
+
+          Logger.info(LOG_PREFIX, `Fullaudio source WebRTC relay successfully created`,
+            { ...this._getPartialLogMetadata(), mediaId: this.sourceAudio, userId: this.userId });
+          return resolve(true);
+      } catch (error) {
+        Logger.error(LOG_PREFIX, `Error on starting fullaudio source WebRTC relay`,
+          { ...this._getPartialLogMetadata(), error });
+        this.sourceAudioStatus = C.MEDIA_NEGOTIATION_FAILED;
+        this._stopSourceAudio();
+        return reject(error);
+      }
+    });
   }
 
   _startGABridge (transportType) {
@@ -600,7 +701,12 @@ module.exports = class Audio extends BaseProvider {
     }
   }
 
-  async start (sessionId, connectionId, sdpOffer, userId, userName) {
+  startFullAudioBridge () {
+    return this._startFullAudioBridge(C.RTP);
+  }
+
+  async start (sessionId, connectionId, sdpOffer, userId, userName,
+    role, caleeName) {
     let mcsUserId;
     const isConnected = await this.mcs.waitForConnection();
 
@@ -608,22 +714,36 @@ module.exports = class Audio extends BaseProvider {
       throw this._handleError(LOG_PREFIX, errors.MEDIA_SERVER_OFFLINE, "recv", userId);
     }
 
-    try {
-      await this.getGlobalAudioPermission(this.meetingId, this.voiceBridge, userId, connectionId);
-    } catch (error) {
-      const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
-      Logger.error(LOG_PREFIX, 'New listen only session failed: unauthorized',
-        { ...this._getPartialLogMetadata(), error: normalizedError });
-      throw normalizedError;
-    }
+    this.caleeName = caleeName;
+    this.role = role;
 
-    try {
-      await this._waitForGlobalAudio();
-    } catch (error) {
-      const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
-      Logger.error(LOG_PREFIX, `New listen only session failed: GLOBAL_AUDIO unavailable`,
-        { ...this._getPartialLogMetadata(), error: normalizedError });
-      throw errors.SFU_GLOBAL_AUDIO_FAILED;
+    switch (role) {
+      case 'sendrecv':
+        await this.getFullAudioPermission(this.meetingId, this.voiceBridge,
+          userId, connectionId);
+
+        await this._waitForFullAudio();
+        break
+      case 'recvonly':
+      default:
+        try {
+          await this.getGlobalAudioPermission(this.meetingId, this.voiceBridge, userId, connectionId);
+        } catch (error) {
+          const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
+          Logger.error(LOG_PREFIX, 'New listen only session failed: unauthorized',
+            { ...this._getPartialLogMetadata(), error: normalizedError });
+          throw normalizedError;
+        }
+
+        try {
+          await this._waitForGlobalAudio();
+        } catch (error) {
+          const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
+          Logger.error(LOG_PREFIX, `New listen only session failed: GLOBAL_AUDIO unavailable`,
+            { ...this._getPartialLogMetadata(), error: normalizedError });
+          throw errors.SFU_GLOBAL_AUDIO_FAILED;
+        }
+        break;
     }
 
     try {
@@ -650,7 +770,10 @@ module.exports = class Audio extends BaseProvider {
       this._getFullLogMetadata(connectionId));
 
     try {
-      const sdpAnswer = await this._subscribeToGlobalAudio(sdpOffer, connectionId);
+      const sdpAnswer = (role === 'sendrecv')
+      ? await this._subscribeToFullAudio(sdpOffer, connectionId, role)
+      : await this._subscribeToGlobalAudio(sdpOffer, connectionId)
+
       return sdpAnswer;
     } catch (error) {
       const normalizedError = this._handleError(LOG_PREFIX, error, "recv", userId);
@@ -665,6 +788,49 @@ module.exports = class Audio extends BaseProvider {
       this.sendUserDisconnectedFromGlobalAudioMessage(connectionId);
       throw normalizedError;
     }
+  }
+
+  async _subscribeToFullAudio(sdpOffer, connectionId, role) {
+    const { userId, mcsUserId } = this.getUser(connectionId);
+    const options = {
+      descriptor: sdpOffer,
+      adapter: this.mediaServer,
+      name: this._assembleStreamName('subscribe', userId, this.meetingId),
+      ignoreThresholds: true,
+      profiles: {
+        audio: role,
+      },
+      mediaProfile: 'audio',
+    }
+
+    let mediaId, answer;
+
+    try {
+      ({ mediaId, answer } = await this.mcs.subscribe(mcsUserId,
+        this.sourceAudio, C.WEBRTC, options));
+
+        this.mcs.connect(mediaId, [this.sourceAudio]);
+    } catch (subscribeError) {
+      Logger.error(LOG_PREFIX, `New fullaudio session failed to subscribe to
+        full audio`,
+        { ...this._getPartialLogMetadata(), subscribeError});
+      throw (this._handleError(LOG_PREFIX, subscribeError, "recv",
+        connectionId));
+    }
+
+    this.mcs.onEvent(C.MEDIA_STATE, mediaId, (event) => {
+      this._mediaStateWebRTC(event, mediaId, connectionId, { role });
+    });
+
+    this.mcs.onEvent(C.MEDIA_STATE_ICE, mediaId, (event) => {
+      this._onMCSIceCandidate(event, mediaId, connectionId);
+    });
+
+    this.audioEndpoints[connectionId] = { mcsUserId, mediaId };
+    this._flushCandidatesQueue(connectionId);
+    Logger.info(LOG_PREFIX, 'Fullaudio session subscribed',
+      this._getFullLogMetadata(connectionId));
+    return answer;
   }
 
   async _subscribeToGlobalAudio (sdpOffer, connectionId) {

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -142,6 +142,8 @@ const config = require('config');
         AUDIO_PROCESS_PREFIX: '[AudioProcess]',
         AUDIO_MANAGER_PREFIX: '[AudioManager]',
         AUDIO_PROVIDER_PREFIX: '[AudioProvider]',
+        FULLAUDIO_PROCESS_PREFIX: '[FullAudioProcess]',
+        FULLAUDIO_MANAGER_PREFIX: '[FullAudioManager]',
 
         // MCS error codes
         MEDIA_SERVER_OFFLINE: 2001,

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -152,18 +152,9 @@ module.exports = class MediaController {
       user = this.getUser(userId);
       room = this.getRoom(user.roomId);
     } catch (error) {
-
-      if (error === C.ERROR.USER_NOT_FOUND) {
-        Logger.debug(
-          LOG_PREFIX,
-          `User with userId=${userId} already left the room`,
-        );
-      } else {
-        Logger.warn(LOG_PREFIX, `Leave for ${userId} failed due to ${error.message}`, { roomId, userId, error });
-      }
-
       // User or room were already closed or not found, resolving as it is
       const normalizedError = this._handleError(error);
+      Logger.warn(LOG_PREFIX, `Leave for ${userId} failed due to ${error.message}`, { roomId, userId, error });
       throw (normalizedError);
     }
 

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -800,13 +800,23 @@ module.exports = class MediaController {
     }
   }
 
-  releaseConferenceFloor (roomId, preserve = true) {
+  releaseConferenceFloor(roomId, preserve = true) {
     try {
       const room = this.getRoom(roomId);
+
+      if (!room) return;
+
       return room.releaseConferenceFloor(preserve);
     } catch (error) {
+      if (error.message === C.ERROR.ROOM_NOT_FOUND.message) {
+        Logger.info(LOG_PREFIX, `Ignoring releaseConferenceFloor for room ` +
+          `${roomId}. This room was already removed`);
+          return;
+      }
+
       Logger.error(LOG_PREFIX, `releaseConferenceFloor for room ${roomId} failed due to ${error.message}`,
         { roomId, error });
+
       throw (this._handleError(error));
     }
   }

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -134,8 +134,15 @@ module.exports = class MediaController {
       this.leave(roomId, userId, C.INTERNAL_TRACKING_ID)
       Logger.info(LOG_PREFIX, "User ejected", { userId, externalUserId, roomId });
     } catch (error) {
-      Logger.error(LOG_PREFIX, `Auto eject for user ${userId} at ${roomId} failed due to ${error.message}`,
-        { roomId, userId, externalUserId, error });
+      if (error === C.ERROR.USER_NOT_FOUND) {
+        Logger.debug(
+          LOG_PREFIX,
+          `User with userId=${userId} already left the room, skipping ejection`,
+        );
+      } else {
+        Logger.error(LOG_PREFIX, `Auto eject for user ${userId} at ${roomId} failed due to ${error.message}`,
+          { roomId, userId, externalUserId, error });
+      }
     }
   }
 
@@ -145,9 +152,18 @@ module.exports = class MediaController {
       user = this.getUser(userId);
       room = this.getRoom(user.roomId);
     } catch (error) {
+
+      if (error === C.ERROR.USER_NOT_FOUND) {
+        Logger.debug(
+          LOG_PREFIX,
+          `User with userId=${userId} already left the room`,
+        );
+      } else {
+        Logger.warn(LOG_PREFIX, `Leave for ${userId} failed due to ${error.message}`, { roomId, userId, error });
+      }
+
       // User or room were already closed or not found, resolving as it is
       const normalizedError = this._handleError(error);
-      Logger.warn(LOG_PREFIX, `Leave for ${userId} failed due to ${error.message}`, { roomId, userId, error });
       throw (normalizedError);
     }
 


### PR DESCRIPTION
Adds a new module (FullAudio) which is able to handle microphone requests (send/receive audio).
This new module routes microphone flow from Browser <-> MediaServer (kurento or mediasoup) <-> FreeSWITCH.
This is still experimental and currently works with Kurento only (though i already tested a different code with success using mediasoup).
I will keep working on this to fully enable two-way audio using mediasoup and at some point we will switch to it as default media server for both microphone and listenonly.