### PR TITLE
feat(audio): initial version of internal, transparent listen only mode

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -138,6 +138,9 @@ fullAudioEnabled:
 audioIceRestartEnabled:
   __name: AUDIO_ICE_RESTART
   __format: json
+transparentListenOnly:
+  __name: TRANSPARENT_LISTEN_ONLY
+  __format: json
 
 audioIgnoreMediaThresholds:
   __name: AUDIO_IGNORE_MEDIA_THRESHOLDS

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -62,6 +62,7 @@ videoMediaServer: mediasoup
 screenshareMediaServer: mediasoup
 audioMediaServer: mediasoup
 fullAudioEnabled: true
+transparentListenOnly: false
 fullAudioProxyActiveDirection: true
 audioIceRestartEnabled: false
 # RTP|WebRTC. Dictates how the FS <-> [audioMediaServer] bridge is established:

--- a/lib/audio/audio-req-hdlr.js
+++ b/lib/audio/audio-req-hdlr.js
@@ -237,6 +237,7 @@ module.exports = class AudioReqHdlr extends BaseManager {
       mediaServer = AUDIO_MEDIA_SERVER,
       role,
       extension,
+      transparentListenOnly,
     } = message;
 
     try {
@@ -274,7 +275,9 @@ module.exports = class AudioReqHdlr extends BaseManager {
         role,
         this.mcs,
         mediaServer,
-        extension,
+        extension, {
+          transparentListenOnly,
+        }
       );
 
       this.storeSession(sessionId, session);

--- a/lib/audio/audio-session.js
+++ b/lib/audio/audio-session.js
@@ -49,6 +49,7 @@ module.exports = class AudioSession extends BaseProvider {
     this.mcsUserId = null;
 
     this.disconnectUser = this.disconnectUser.bind(this);
+    this.toggleRecvOnlyMode = this.toggleRecvOnlyMode.bind(this);
     this.handleMCSCoreDisconnection = this.handleMCSCoreDisconnection.bind(this);
 
     this._trackMeetingEvents();
@@ -104,10 +105,19 @@ module.exports = class AudioSession extends BaseProvider {
     if (EJECT_ON_USER_LEFT) {
       this.bbbGW.once(C.USER_LEFT_MEETING_2x+this.userId, this.disconnectUser);
     }
+
+    this.bbbGW.on(
+      C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG+this.userId,
+      this.toggleRecvOnlyMode
+    );
   }
 
   _untrackMeetingEvents () {
     this.bbbGW.removeListener(C.USER_LEFT_MEETING_2x+this.userId, this.disconnectUser);
+    this.bbbGW.removeListener(
+      C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG+this.userId,
+      this.toggleRecvOnlyMode
+    );
   }
 
   _untrackMCSEvents () {
@@ -265,7 +275,7 @@ module.exports = class AudioSession extends BaseProvider {
     this.clientEndpoint = null;
   }
 
-  async disconnectUser() {
+  async disconnectUser () {
     try {
       await this.stop('user_left');
     } catch (error) {
@@ -279,4 +289,15 @@ module.exports = class AudioSession extends BaseProvider {
       }, C.FROM_AUDIO);
     }
   }
-};
+
+  async toggleRecvOnlyMode (enabled) {
+    if (this.role !== 'sendrecv' || this.clientEndpoint == null) return;
+
+    if (this.clientEndpoint.consumerBridge == null) {
+      const consumerBridge = await this._startConsumerBridge();
+      this.clientEndpoint.consumerBridge = consumerBridge;
+    }
+
+    this.clientEndpoint.toggleRecvOnlyMode(enabled);
+  }
+}

--- a/lib/audio/audio-session.js
+++ b/lib/audio/audio-session.js
@@ -17,6 +17,9 @@ const EJECT_ON_USER_LEFT = config.get('ejectOnUserLeft');
 const FULLAUDIO_ENABLED = config.has('fullAudioEnabled')
   ? config.get('fullAudioEnabled')
   : false;
+const TRANSPARENT_LISTEN_ONLY = config.has('transparentListenOnly')
+  ? config.get('transparentListenOnly')
+  : false;
 
 module.exports = class AudioSession extends BaseProvider {
   constructor(
@@ -31,6 +34,7 @@ module.exports = class AudioSession extends BaseProvider {
     mcs,
     mediaServer,
     extension,
+    options = {}
   ) {
     super(bbbGW);
     this.sfuApp = C.AUDIO_APP;
@@ -44,6 +48,8 @@ module.exports = class AudioSession extends BaseProvider {
     this.mcs = mcs;
     this.mediaServer = mediaServer;
     this.extension = extension;
+    this.transparentListenOnly = TRANSPARENT_LISTEN_ONLY
+      && (options?.transparentListenOnly ?? false);
 
     this.clientEndpoint = null;
     this.mcsUserId = null;
@@ -106,10 +112,12 @@ module.exports = class AudioSession extends BaseProvider {
       this.bbbGW.once(C.USER_LEFT_MEETING_2x+this.userId, this.disconnectUser);
     }
 
-    this.bbbGW.on(
-      C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG+this.userId,
-      this.toggleRecvOnlyMode
-    );
+    if (this.transparentListenOnly) {
+      this.bbbGW.on(
+        C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG+this.userId,
+        this.toggleRecvOnlyMode
+      );
+    }
   }
 
   _untrackMeetingEvents () {
@@ -141,7 +149,9 @@ module.exports = class AudioSession extends BaseProvider {
   /* ======= START/CONNECTION METHODS ======= */
 
   async transceive(sdpOffer) {
+    let consumerBridge;
     if (!FULLAUDIO_ENABLED) throw SFUErrors.SFU_INVALID_REQUEST;
+    if (this.transparentListenOnly) consumerBridge = await this._startConsumerBridge();
 
     this.clientEndpoint = new ClientAudioStTransceiver(
       this.bbbGW,
@@ -153,6 +163,7 @@ module.exports = class AudioSession extends BaseProvider {
       this.mcs, {
         mediaServer: this.mediaServer,
         extension: this.extension,
+        consumerBridge,
       }
     );
 

--- a/lib/audio/audio-session.js
+++ b/lib/audio/audio-session.js
@@ -12,6 +12,7 @@ const {
   getConsumerBridge,
   storeConsumerBridge,
 } = require('./consumer-bridge-storage.js');
+const Messaging = require('../bbb/messages/Messaging.js');
 
 const EJECT_ON_USER_LEFT = config.get('ejectOnUserLeft');
 const FULLAUDIO_ENABLED = config.has('fullAudioEnabled')
@@ -55,7 +56,7 @@ module.exports = class AudioSession extends BaseProvider {
     this.mcsUserId = null;
 
     this.disconnectUser = this.disconnectUser.bind(this);
-    this.toggleRecvOnlyMode = this.toggleRecvOnlyMode.bind(this);
+    this.toggleListenOnlyMode = this.toggleListenOnlyMode.bind(this);
     this.handleMCSCoreDisconnection = this.handleMCSCoreDisconnection.bind(this);
 
     this._trackMeetingEvents();
@@ -115,7 +116,7 @@ module.exports = class AudioSession extends BaseProvider {
     if (this.transparentListenOnly) {
       this.bbbGW.on(
         C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG+this.userId,
-        this.toggleRecvOnlyMode
+        this.toggleListenOnlyMode
       );
     }
   }
@@ -124,7 +125,7 @@ module.exports = class AudioSession extends BaseProvider {
     this.bbbGW.removeListener(C.USER_LEFT_MEETING_2x+this.userId, this.disconnectUser);
     this.bbbGW.removeListener(
       C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG+this.userId,
-      this.toggleRecvOnlyMode
+      this.toggleListenOnlyMode
     );
   }
 
@@ -301,14 +302,42 @@ module.exports = class AudioSession extends BaseProvider {
     }
   }
 
-  async toggleRecvOnlyMode (enabled) {
-    if (this.role !== 'sendrecv' || this.clientEndpoint == null) return;
+  _notifyRecvOnlyModeToggled (enabled) {
+    const msg = Messaging.generateListenOnlyModeToggledEvtMsg(
+      this.meetingId,
+      this.voiceBridge,
+      this.userId,
+      enabled
+    );
+    this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
+  }
+
+  async toggleListenOnlyMode ({ meetingId, voiceConf, enabled }) {
+    if (this.clientEndpoint == null
+      || this.role !== 'sendrecv'
+      || this.clientEndpoint instanceof ClientAudioConsumer
+      || this.meetingId !== meetingId
+      || this.voiceBridge !== voiceConf
+    ) {
+      Logger.warn('Audio session: toggle recv-only mode: not applicable', {
+        ...this._getFullLogMetadata(this.connectionId),
+      });
+      return;
+    }
 
     if (this.clientEndpoint.consumerBridge == null) {
       const consumerBridge = await this._startConsumerBridge();
       this.clientEndpoint.consumerBridge = consumerBridge;
     }
 
-    this.clientEndpoint.toggleRecvOnlyMode(enabled);
+    this.clientEndpoint.toggleListenOnlyMode(enabled).then(() => {
+      this._notifyRecvOnlyModeToggled(enabled);
+    }).catch((error) => {
+      Logger.error('Audio session: failure to toggle recv-only mode', {
+        ...this._getFullLogMetadata(this.connectionId),
+        errorMessage: error.message,
+        errorCode: error.code
+      });
+    });
   }
 }

--- a/lib/audio/client-static-transceiver.js
+++ b/lib/audio/client-static-transceiver.js
@@ -7,7 +7,6 @@ const BaseProvider = require('../base/base-provider.js');
 const errors = require('../base/errors.js');
 const FSTransceiverBridge = require('./fs-transceiver-bridge.js');
 const { getAudioRtpHdrExts } = require('./utils.js');
-const Messaging = require('../bbb/messages/Messaging.js');
 
 const LOG_PREFIX = '[client-audio-static-transceiver]';
 const MEDIA_FLOW_TIMEOUT_DURATION = config.get('mediaFlowTimeoutDuration');
@@ -312,27 +311,18 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
     }
   }
 
-  notifyRecvOnlyModeToggled (enabled) {
-    const msg = Messaging.generateListenOnlyModeToggledEvtMsg(
-      this.meetingId,
-      this.voiceBridge,
-      this.userId,
-      enabled
-    );
-    this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
-  }
+  toggleListenOnlyMode (enabled) {
+    let source;
 
-  toggleRecvOnlyMode (enabled) {
     if (enabled) {
       Logger.trace("Switching to recvonly", this.userId);
-      this.mcs.connect(this.consumerBridge.bridgeMediaId, [this.mediaId], 'AUDIO');
+      source = this.consumerBridge.bridgeMediaId;
     } else {
       Logger.trace("Switching to sendrecv", this.userId);
-      this.mcs.connect(this.transceiverBridge.bridgeMediaId, [this.mediaId], 'AUDIO');
+      source = this.transceiverBridge.bridgeMediaId;
     }
 
-    // TODO sync conn-notify -> handle timing and errors
-    this.notifyRecvOnlyModeToggled(enabled);
+    return this.mcs.connect(source, [this.mediaId], 'AUDIO');
   }
 
   async _negotiateTransceiver(sdpOffer) {

--- a/lib/audio/client-static-transceiver.js
+++ b/lib/audio/client-static-transceiver.js
@@ -346,7 +346,7 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
       },
       mediaProfile: 'audio',
       adapterOptions: {
-        overrideRouterCodecs: true,
+        overrideRouterCodecs: false,
         dedicatedRouter:  false,
         rtpHeaderExtensions: AUDIO_RTP_HDR_EXTS,
       }
@@ -395,6 +395,7 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
   processAnswer (answer) {
     if (this.mediaId) {
       const options = {
+        mediaId: this.mediaId,
         descriptor: answer,
         adapter: this.mediaServer,
         name: this._assembleStreamName('publish', this.userId, this.meetingId),
@@ -404,7 +405,7 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
         },
         mediaProfile: 'audio',
         adapterOptions: {
-          overrideRouterCodecs: true,
+          overrideRouterCodecs: false,
           dedicatedRouter:  false,
           rtpHeaderExtensions: AUDIO_RTP_HDR_EXTS,
         }
@@ -415,7 +416,11 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
         this.voiceBridge,
         C.WEBRTC,
         options,
-      );
+      ).then(() => this.mcs.consume(
+        this.mediaId,
+        this.transceiverBridge.bridgeMediaId,
+        'AUDIO'
+      ));
     }
 
     return Promise.resolve();

--- a/lib/audio/client-static-transceiver.js
+++ b/lib/audio/client-static-transceiver.js
@@ -325,7 +325,12 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
     return this.mcs.connect(source, [this.mediaId], 'AUDIO');
   }
 
+  _hasConsumerBridge () {
+    return this.consumerBridge && this.consumerBridge.bridgeMediaId;
+  }
+
   async _negotiateTransceiver(sdpOffer) {
+    let mediaId, answer;
     const options = {
       descriptor: sdpOffer,
       adapter: this.mediaServer,
@@ -342,10 +347,12 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
       }
     }
 
-    let mediaId, answer;
+    if (this._hasConsumerBridge()) {
+      options.adapterOptions.consumeFrom = [this.consumerBridge.bridgeMediaId];
+    }
 
     try {
-      ({ mediaId } = await this.mcs.publish(
+      ({ mediaId, answer } = await this.mcs.publish(
         this.mcsUserId,
         this.voiceBridge,
         C.WEBRTC,
@@ -355,11 +362,15 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
       this.mediaId = mediaId;
       await this.transceiverBridge.start(this.mediaId);
 
-      answer = await this.mcs.consume(
-        this.transceiverBridge.bridgeMediaId,
-        this.mediaId,
-        'AUDIO'
-      );
+      if (!this._hasConsumerBridge()) {
+        answer = await this.mcs.consume(
+          this.transceiverBridge.bridgeMediaId,
+          this.mediaId,
+          'AUDIO'
+        );
+      } else {
+        await this.mcs.connect(this.transceiverBridge.bridgeMediaId, [this.mediaId], 'AUDIO');
+      }
     } catch (error) {
       Logger.error('Client audio transceiver failure', {
         ...this._getFullLogMetadata(),

--- a/lib/audio/client-static-transceiver.js
+++ b/lib/audio/client-static-transceiver.js
@@ -7,6 +7,7 @@ const BaseProvider = require('../base/base-provider.js');
 const errors = require('../base/errors.js');
 const FSTransceiverBridge = require('./fs-transceiver-bridge.js');
 const { getAudioRtpHdrExts } = require('./utils.js');
+const Messaging = require('../bbb/messages/Messaging.js');
 
 const LOG_PREFIX = '[client-audio-static-transceiver]';
 const MEDIA_FLOW_TIMEOUT_DURATION = config.get('mediaFlowTimeoutDuration');
@@ -34,6 +35,7 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
     this.mcs = mcs;
     this.mediaServer = options.mediaServer;
     this.extension = options.extension;
+    this.consumerBridge = options.consumerBridge;
 
     this.transceiverBridge = new FSTransceiverBridge(
       this.mcs,
@@ -310,6 +312,29 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
     }
   }
 
+  notifyRecvOnlyModeToggled (enabled) {
+    const msg = Messaging.generateListenOnlyModeToggledEvtMsg(
+      this.meetingId,
+      this.voiceBridge,
+      this.userId,
+      enabled
+    );
+    this.bbbGW.publish(msg, C.TO_AKKA_APPS_CHAN_2x);
+  }
+
+  toggleRecvOnlyMode (enabled) {
+    if (enabled) {
+      Logger.trace("Switching to recvonly", this.userId);
+      this.mcs.connect(this.consumerBridge.bridgeMediaId, [this.mediaId], 'AUDIO');
+    } else {
+      Logger.trace("Switching to sendrecv", this.userId);
+      this.mcs.connect(this.transceiverBridge.bridgeMediaId, [this.mediaId], 'AUDIO');
+    }
+
+    // TODO sync conn-notify -> handle timing and errors
+    this.notifyRecvOnlyModeToggled(enabled);
+  }
+
   async _negotiateTransceiver(sdpOffer) {
     const options = {
       descriptor: sdpOffer,
@@ -322,7 +347,7 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
       mediaProfile: 'audio',
       adapterOptions: {
         overrideRouterCodecs: true,
-        dedicatedRouter: true,
+        dedicatedRouter:  false,
         rtpHeaderExtensions: AUDIO_RTP_HDR_EXTS,
       }
     }
@@ -345,9 +370,6 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
         this.mediaId,
         'AUDIO'
       );
-
-      this.mcs.connect(this.mediaId, [this.transceiverBridge.bridgeMediaId], 'AUDIO');
-      this.mcs.connect(this.transceiverBridge.bridgeMediaId, [this.mediaId], 'AUDIO');
     } catch (error) {
       Logger.error('Client audio transceiver failure', {
         ...this._getFullLogMetadata(),
@@ -383,7 +405,7 @@ module.exports = class ClientAudioStTransceiver extends BaseProvider {
         mediaProfile: 'audio',
         adapterOptions: {
           overrideRouterCodecs: true,
-          dedicatedRouter: true,
+          dedicatedRouter:  false,
           rtpHeaderExtensions: AUDIO_RTP_HDR_EXTS,
         }
       }

--- a/lib/audio/fs-transceiver-bridge.js
+++ b/lib/audio/fs-transceiver-bridge.js
@@ -125,11 +125,12 @@ module.exports = class FSTransceiverBridge extends EventEmitter {
           name: `PROXY_${this._bridgeMediaName}|transceive`,
           ignoreThresholds: true,
           profiles: {
-            audio: 'sendonly',
+            audio: 'sendrecv',
           },
           hackForceActiveDirection: PROXY_ACTIVE_DIRECTION,
           mediaProfile: 'audio',
           adapterOptions: {
+            overrideDirection: 'sendrecv',
             msHackRTPAVPtoRTPAVPF: true,
             consumeFrom: [ transceiverSourceId ],
             transportOptions: {

--- a/lib/base/MCSAPIWrapper.js
+++ b/lib/base/MCSAPIWrapper.js
@@ -180,13 +180,10 @@ module.exports = class MCSAPIWrapper extends EventEmitter {
     }
   }
 
-  async connect (source, sinks, type) {
-    try {
-      return this._mcs.connect(source, sinks, type);
-    }
-    catch (error) {
+  connect (source, sinks, type) {
+    return this._mcs.connect(source, sinks, type).catch((error) => {
       throw (this._handleError(error, 'connect', { source, sinks, type }));
-    }
+    });
   }
 
   async disconnect (source, sinks, type) {

--- a/lib/bbb/messages/Constants.js
+++ b/lib/bbb/messages/Constants.js
@@ -90,6 +90,7 @@
         GET_CAM_SUBSCRIBE_PERM_RESP_MSG: "GetCamSubscribePermissionRespMsg",
         CAM_STREAM_UNSUBSCRIBE_SYS_MSG: "CamStreamUnsubscribeSysMsg",
         CAM_BROADCAST_STOP_SYS_MSG: "CamBroadcastStopSysMsg",
+        TOGGLE_LISTEN_ONLY_MODE_SYS_MSG: "ToggleListenOnlyModeSysMsg",
 
         STREAM_IS_RECORDED: "StreamIsRecordedMsg",
 
@@ -109,6 +110,7 @@
         STREAM_ID: "streamId",
         SUBSCRIBER_STREAM_ID: "subscriberStreamId",
         CALLER_ID_NUM: "callerIdNum",
+        ENABLED: "enabled",
 
         // Akka Apps 2x
         REQUESTED_BY: "requestedBy",

--- a/lib/bbb/messages/Messaging.js
+++ b/lib/bbb/messages/Messaging.js
@@ -29,6 +29,7 @@ const CamBroadcastStoppedInSfuEvtMsg =
   require('./video/CamBroadcastStoppedInSfuEvtMsg.js');
 const GetMicrophonePermissionReqMsg =
   require('./audio/GetMicrophonePermission.js');
+const ListenOnlyModeToggledEvtMsg = require('./audio/ListenOnlyModeToggledEvtMsg.js');
 
 module.exports = {
   generateScreenshareRTMPBroadcastStartedEvent2x: (
@@ -141,6 +142,14 @@ module.exports = {
   ) => {
     return (new GetMicrophonePermissionReqMsg(
       meetingId, voiceConf, userId, callerIdNum, sfuSessionId,
+    )).toJson();
+  },
+
+  generateListenOnlyModeToggledEvtMsg: (
+    meetingId, voiceConf, userId, enabled,
+  ) => {
+    return (new ListenOnlyModeToggledEvtMsg(
+      meetingId, voiceConf, userId, enabled,
     )).toJson();
   },
 }

--- a/lib/bbb/messages/audio/ListenOnlyModeToggledEvtMsg.js
+++ b/lib/bbb/messages/audio/ListenOnlyModeToggledEvtMsg.js
@@ -1,0 +1,21 @@
+const OutMessage2x = require('../OutMessage2x');
+const Constants = require('../Constants.js');
+
+const LISTEN_ONLY_MODE_TOGGLED_EVT_MSG = "ListenOnlyModeToggledInSfuEvtMsg";
+
+module.exports = class ListenOnlyModeToggledEvtMsg extends OutMessage2x {
+  constructor (meetingId, voiceConf, userId, enabled) {
+    super(
+      LISTEN_ONLY_MODE_TOGGLED_EVT_MSG,
+      { sender: 'bbb-webrtc-sfu' },
+      { voiceConf }
+    );
+
+    this.core.body = {
+      [Constants.MEETING_ID_2x]: meetingId,
+      [Constants.VOICE_CONF_2x]: voiceConf,
+      [Constants.USER_ID_2x]: userId,
+      [Constants.ENABLED]: enabled,
+    }
+  }
+}

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -87,6 +87,10 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
 
     if (header) {
       switch (header.name) {
+        case C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG:
+          this.emit(C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG + payload.userId, payload);
+          this.emit(C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG, payload);
+          break;
         // interoperability with 1.1
         case C.DISCONNECT_ALL_USERS:
           this.emit(C.DISCONNECT_ALL_USERS, payload);

--- a/lib/bbb/pubsub/bbb-gw.js
+++ b/lib/bbb/pubsub/bbb-gw.js
@@ -88,6 +88,7 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
     if (header) {
       switch (header.name) {
         case C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG:
+          payload.meetingId = header.meetingId;
           this.emit(C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG + payload.userId, payload);
           this.emit(C.TOGGLE_LISTEN_ONLY_MODE_SYS_MSG, payload);
           break;

--- a/lib/mcs-core/lib/adapters/mediasoup/base-element.js
+++ b/lib/mcs-core/lib/adapters/mediasoup/base-element.js
@@ -11,6 +11,7 @@ const EventEmitter = require('events').EventEmitter;
 const {
   getMappedTransportType,
   getSpecEntryFromMimeType,
+  mapConnectionTypeToKind,
 } = require('./utils.js');
 const { PrometheusAgent, MS_METRIC_NAMES } = require('./prom-metrics.js');
 const Logger = require('../../utils/logger');
@@ -482,6 +483,29 @@ module.exports = class BaseMediasoupElement extends EventEmitter {
 
   async connect (sourceElement, type) {
     return this._connect(sourceElement, type);
+  }
+
+  // Users changeProducer to set this element's consumers to sourceElement's
+  // producers
+  async changeProducer(sourceElement, type) {
+    try {
+      const mappedType = mapConnectionTypeToKind(type)[0];
+      this.consumers.forEach(consumer => {
+        if (consumer.kind !== mappedType) return;
+
+        const producer = sourceElement.getProducerOfKind(consumer.kind);
+
+        if (producer) consumer.changeProducer(producer.id);
+      });
+    } catch (error) {
+      Logger.error('mediasoup: changeProducer failed', {
+        error,
+        errorMessage: error.message,
+        elementId: this.id,
+        sourceElementId: sourceElement.id,
+        type,
+      });
+    }
   }
 
   _restartIce () {

--- a/lib/mcs-core/lib/adapters/mediasoup/mediasoup-adapter.js
+++ b/lib/mcs-core/lib/adapters/mediasoup/mediasoup-adapter.js
@@ -359,9 +359,21 @@ module.exports = class MediasoupAdapter extends EventEmitter {
   //
   // So yeah. Some work needed (mainly client side) - prlanzarin mar 13 2021
   // eslint-disable-next-line no-unused-vars
-  connect (sourceId, sinkId, type) {
-    // Passthrough for now
-    return Promise.resolve();
+  async connect (sourceId, sinkId, type) {
+    try {
+      const sourceElement = MediaElements.getElement(sourceId);
+      const sinkElement = MediaElements.getElement(sinkId);
+      if (sourceElement && sinkElement) {
+        await sinkElement.changeProducer(sourceElement, type);
+      } else {
+        throw handleError({
+          ...C.ERROR.MEDIA_NOT_FOUND,
+          details: "MEDIASOUP_CONSUME_ELEMENTS_NOT_FOUND",
+        });
+      }
+    } catch (error) {
+      throw (handleError(error));
+    }
   }
 
   async consume (sinkId, sourceId, type) {

--- a/lib/mcs-core/lib/api/mcs-message-router.js
+++ b/lib/mcs-core/lib/api/mcs-message-router.js
@@ -151,9 +151,7 @@ module.exports = class MCSRouter {
         this._mediaController.connect(source_id, sink, type);
       });
 
-      await Promise.all(cPromises).then(() => {
-        return;
-      }).catch((err) => {
+      await Promise.all(cPromises).catch((err) => {
         throw (this._handleError(err, 'connect', { source_id, sink_ids, type }));
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "js-yaml": "4.1.0",
         "kurento-client": "github:mconf/kurento-client-js#v6.18.0-mconf.1",
         "mcs-js": "github:mconf/mcs-js#v0.0.17",
-        "mediasoup": "3.12.8",
+        "mediasoup": "github:mconf/mediasoup#3.12.8-bbb.1",
         "mediasoup-client": "3.6.84",
         "modesl": "1.2.1",
         "pegjs": "0.8.0",
@@ -1291,9 +1291,9 @@
     },
     "node_modules/mediasoup": {
       "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.12.8.tgz",
-      "integrity": "sha512-8K3UlFq9ZTnRbIWjrU/4WDWptKIBZfyqWrXMsaORc2uPmVfwSbMl0aMPc55FA64hg957l8QzKPnFkGBZgg7/4g==",
+      "resolved": "git+ssh://git@github.com/mconf/mediasoup.git#b08d8fe457cb82ecd932e509087a47138efd2b9c",
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",
         "h264-profile-level-id": "^1.0.1",
@@ -3333,9 +3333,8 @@
       }
     },
     "mediasoup": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.12.8.tgz",
-      "integrity": "sha512-8K3UlFq9ZTnRbIWjrU/4WDWptKIBZfyqWrXMsaORc2uPmVfwSbMl0aMPc55FA64hg957l8QzKPnFkGBZgg7/4g==",
+      "version": "git+ssh://git@github.com/mconf/mediasoup.git#b08d8fe457cb82ecd932e509087a47138efd2b9c",
+      "from": "mediasoup@github:mconf/mediasoup#3.12.8-bbb.1",
       "requires": {
         "debug": "^4.3.4",
         "h264-profile-level-id": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ipaddr.js": "1.9.1",
         "js-yaml": "4.1.0",
         "kurento-client": "github:mconf/kurento-client-js#v6.18.0-mconf.1",
-        "mcs-js": "github:mconf/mcs-js#v0.0.17",
+        "mcs-js": "github:mconf/mcs-js#v0.0.18",
         "mediasoup": "github:mconf/mediasoup#3.12.8-bbb.1",
         "mediasoup-client": "3.6.84",
         "modesl": "1.2.1",
@@ -1278,8 +1278,8 @@
       }
     },
     "node_modules/mcs-js": {
-      "version": "0.0.17",
-      "resolved": "git+ssh://git@github.com/mconf/mcs-js.git#690c4affdf1fa155abeca7b58155bfeaa14593cb",
+      "version": "0.0.18",
+      "resolved": "git+ssh://git@github.com/mconf/mcs-js.git#57e074ed6dd46eec257ae2de785957320852094a",
       "dependencies": {
         "uuid": "^9.0.0",
         "ws": "^8.12.1"
@@ -3323,8 +3323,8 @@
       }
     },
     "mcs-js": {
-      "version": "git+ssh://git@github.com/mconf/mcs-js.git#690c4affdf1fa155abeca7b58155bfeaa14593cb",
-      "from": "mcs-js@github:mconf/mcs-js#v0.0.17",
+      "version": "git+ssh://git@github.com/mconf/mcs-js.git#57e074ed6dd46eec257ae2de785957320852094a",
+      "from": "mcs-js@github:mconf/mcs-js#v0.0.18",
       "requires": {
         "bufferutil": "^4.0.6",
         "utf-8-validate": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "js-yaml": "4.1.0",
     "kurento-client": "github:mconf/kurento-client-js#v6.18.0-mconf.1",
     "mcs-js": "github:mconf/mcs-js#v0.0.17",
-    "mediasoup": "3.12.8",
+    "mediasoup": "github:mconf/mediasoup#3.12.8-bbb.1",
     "mediasoup-client": "3.6.84",
     "modesl": "1.2.1",
     "pegjs": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ipaddr.js": "1.9.1",
     "js-yaml": "4.1.0",
     "kurento-client": "github:mconf/kurento-client-js#v6.18.0-mconf.1",
-    "mcs-js": "github:mconf/mcs-js#v0.0.17",
+    "mcs-js": "github:mconf/mcs-js#v0.0.18",
     "mediasoup": "github:mconf/mediasoup#3.12.8-bbb.1",
     "mediasoup-client": "3.6.84",
     "modesl": "1.2.1",


### PR DESCRIPTION
### New configuration flags:
  - `TRANSPARENT_LISTEN_ONLY` (environment variable, boolean)
  - `transparentListenOnly` (file, boolean)
  - Feature is **off by default**

### Changes  
- [feat(audio): toggle sendrecv/recvonly modes internally, on demand](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/8bd9d47c6e3f09620ddec7d34dd9776d0c74b1f6)
- [feat(audio): support offerer role for mic/sendrecv streams](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/a922ddb2e4870bb2a0deb4c2b181b92f2908aea9)
- [build(mcs-js): v0.0.18](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/08612cf9ec1683e1a96668066979adf1feabc117)
- [fix(audio): peg transceivers to global audio bridge routers](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/8a7d2bea307e1b52247fb16fcdb65559fce23227)
- [build(mediasoup): github:mconf/mediasoup#3.12.8-bbb.1](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/8bd9d47c6e3f09620ddec7d34dd9776d0c74b1f6)
  * Forked version of mediasoup with changes necessary to support the transparent listen only feature

